### PR TITLE
Avoid instantiating `S3FileManager` when S3 configuration is missing

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -1,7 +1,8 @@
 package org.bigbluebutton.presentation.imp;
 
 import com.google.gson.Gson;
-import org.bigbluebutton.api.Util;
+import org.bigbluebutton.api.domain.Meeting;
+import org.bigbluebutton.api.service.ServiceUtils;
 import org.bigbluebutton.presentation.messages.IPresentationCompletionMessage;
 import org.bigbluebutton.presentation.messages.PageConvertProgressMessage;
 import org.bigbluebutton.presentation.messages.PresentationConvertMessage;
@@ -85,8 +86,8 @@ public class PresentationConversionCompletionService {
         if(!p.pres.getUploadedFileHash().isEmpty()) {
             try {
                 String remoteFileName = p.pres.getUploadedFileHash() + ".tar.gz";
-                boolean isPresentationConversionCacheEnabled = s3FileManager.isPresentationConversionCacheEnabled(meetingId);
-                if(isPresentationConversionCacheEnabled && !s3FileManager.exists(remoteFileName)) {
+                Meeting meeting = ServiceUtils.findMeetingFromMeetingID(meetingId);
+                if(meeting.isPresentationConversionCacheEnabled() && !s3FileManager.exists(remoteFileName)) {
                     File parentDir = new File(p.pres.getUploadedFile().getParent());
                     File compressedFile = TarGzManager.compress(
                             parentDir.getAbsolutePath(),

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.google.gson.Gson;
 import org.apache.commons.io.FilenameUtils;
 import org.bigbluebutton.api.Util;
+import org.bigbluebutton.api.domain.Meeting;
+import org.bigbluebutton.api.service.ServiceUtils;
 import org.bigbluebutton.presentation.*;
 import org.bigbluebutton.presentation.messages.*;
 import org.slf4j.Logger;
@@ -62,8 +64,8 @@ public class PresentationFileProcessor {
         try {
             pres.setUploadedFileHash(s3FileManager.generateHash(pres.getUploadedFile()));
             String remoteFileName = pres.getUploadedFileHash() + ".tar.gz";
-            boolean isPresentationConversionCacheEnabled = s3FileManager.isPresentationConversionCacheEnabled(meetingId);
-            if(isPresentationConversionCacheEnabled && s3FileManager.exists(remoteFileName)) {
+            Meeting meeting = ServiceUtils.findMeetingFromMeetingID(meetingId);
+            if(meeting.isPresentationConversionCacheEnabled() && s3FileManager.exists(remoteFileName)) {
                 S3Object s3Object = s3FileManager.download(remoteFileName);
                 File parentDir = new File(pres.getUploadedFile().getParent());
                 TarGzManager.decompress(s3Object, parentDir.getAbsolutePath());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/S3FileManager.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/S3FileManager.java
@@ -9,8 +9,6 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import org.bigbluebutton.api.domain.Meeting;
-import org.bigbluebutton.api.service.ServiceUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,7 +27,7 @@ public class S3FileManager {
     private AmazonS3 s3Client = null;
 
     public AmazonS3 getS3Client() {
-        if(s3Client == null) {
+        if(s3Client == null && !endpointUrl.isEmpty()) {
             AWSCredentials credentials = new BasicAWSCredentials(accessKeyId, accessKeySecret);
             s3Client = AmazonS3ClientBuilder.standard()
                     .withCredentials(new AWSStaticCredentialsProvider(credentials))
@@ -74,12 +72,6 @@ public class S3FileManager {
             hashString.append(String.format("%02x", b));
         }
         return hashString.toString();
-    }
-
-
-    public boolean isPresentationConversionCacheEnabled(String meetingId) {
-        Meeting meeting = ServiceUtils.findMeetingFromMeetingID(meetingId);
-        return meeting.isPresentationConversionCacheEnabled();
     }
 
     public String getAccessKeyId() {


### PR DESCRIPTION
Previously, an error was always logged because the system attempted to load the `S3FileManager` class to check `isPresentationConversionCacheEnabled`. However, this required loading properties from `bbb-web.properties`, which are commented out by default and therefore do not exist.


This PR prevents `S3FileManager` from being instantiated unless `presentationConversionCacheEnabled` is explicitly set to `true`. 


Additionally, even when `presentationConversionCacheEnabled=true`, it will not attempt to connect if `endpointUrl` is empty. This handles cases where `presentationConversionCacheEnabled=true` is set via `/CREATE` but the S3 destination is not configured in `bbb-web.properties`.