### PR TITLE
Handle markdown images adjusting max-height and increase grid row height

### DIFF
--- a/bbb-learning-dashboard/src/components/PluginsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PluginsTable.jsx
@@ -88,6 +88,24 @@ const PluginsTable = (props) => {
                   {children}
                 </a>
               ),
+              img: ({
+                node, src, alt, ...restProps
+              }) => (
+                <a href={src} target="_blank" rel="noopener noreferrer" className="block border border-gray-300">
+                  <img
+                    src={src}
+                    alt={alt}
+                    {...restProps}
+                    style={{
+                      maxHeight: '120px',
+                      height: 'auto',
+                      maxWidth: '120px',
+                      width: 'auto',
+                      cursor: 'pointer',
+                    }}
+                  />
+                </a>
+              ),
             }}
           >
             {value}
@@ -105,7 +123,7 @@ const PluginsTable = (props) => {
     disableColumnMenu: true,
     disableColumnSelector: true,
     disableSelectionOnClick: true,
-    rowHeight: 45,
+    rowHeight: 125,
   };
 
   return (


### PR DESCRIPTION
It now supports images using markdown syntax, so we need to ensure they're displayed properly within the grid height constraints. 
I also increased the row height to accommodate plugins that may use markdown to send larger content.

<img width="2488" height="1318" alt="image" src="https://github.com/user-attachments/assets/cad8cd11-9a4e-4adb-b8a0-3cd370ae6605" />
