### PR TITLE
fix(shared-notes): keep BlockNote table add-row handle inside the panel

### DIFF
--- a/bbb-shared-notes-server/src/redis/handler.ts
+++ b/bbb-shared-notes-server/src/redis/handler.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { uploadPresentation } from './service/uploadPresentation';
 import { documentNamePrefix } from '../hocuspocus/utils';
 import { pushInitialContent } from './service/pushInitialContent';
+import { appendPollChartToNotes, PieEntry } from './service/appendPollChart';
 import { markDocumentEnded } from '../hocuspocus/extensions/postgresql';
 
 const logger = new Logger('redis handler');
@@ -147,6 +148,43 @@ const handleSharedNotesCreate = async (header: MessageHeader, body: MessageBody)
   }
 
   sender.send('sharedNotesCreated', meetingId, { padId, externalId, model });
+};
+
+const handlePollShowResult = async (header: MessageHeader, body: MessageBody): Promise<void> => {
+  const { meetingId } = header;
+  const { pollId, poll } = body;
+
+  if (typeof pollId !== 'string' || pollId === '' || poll === null || typeof poll !== 'object') {
+    logger.warn('Ignoring malformed PollShowResultEvtMsg', { meetingId });
+    return;
+  }
+
+  const answers = Array.isArray(poll.answers) ? poll.answers : [];
+
+  // Build the pie data defensively: the html5 validator (parseChartSpec) DROPS
+  // entries with an empty/non-string label or a non-finite/negative value, so a
+  // server-written chart would be silently emptied otherwise. Guarantee a non-empty
+  // label (fall back to "Option N") and a finite value >= 0 for every answer.
+  const data: PieEntry[] = answers.map((answer: any, index: number) => {
+    const key = answer?.key;
+    const label = typeof key === 'string' && key.trim() !== '' ? key.trim() : `Option ${index + 1}`;
+    const numVotes = answer?.numVotes;
+    const value = typeof numVotes === 'number' && Number.isFinite(numVotes) && numVotes >= 0 ? numVotes : 0;
+    return { label, value };
+  });
+
+  if (data.length === 0) {
+    logger.warn('PollShowResultEvtMsg has no answers, skipping chart', { meetingId, pollId });
+    return;
+  }
+
+  const padId = `${documentNamePrefix}${meetingId}`;
+  const statusReturn = await appendPollChartToNotes(padId, pollId, data);
+  if (statusReturn.error) {
+    logger.error('Failed to write poll chart to notes', {
+      ...statusReturn, meetingId, pollId, padId,
+    });
+  }
 };
 
 const handleBlockNoteExport = async (header: MessageHeader, body: MessageBody): Promise<void> => {
@@ -350,6 +388,9 @@ const handler: PubSubHandler = {
           break;
         case 'BNSharedNotesCreateCmdMsg':
           await handleSharedNotesCreate(header, body);
+          break;
+        case 'PollShowResultEvtMsg':
+          await handlePollShowResult(header, body);
           break;
         case 'ExportBNSharedNotesEvtMsg':
           await handleBlockNoteExport(header, body);

--- a/bbb-shared-notes-server/src/redis/service/appendPollChart.ts
+++ b/bbb-shared-notes-server/src/redis/service/appendPollChart.ts
@@ -1,0 +1,87 @@
+import hocuspocus from '../../hocuspocus';
+import { Logger } from '../../common/logger';
+import { getNotesEditor } from './notesSchema';
+
+const logger = new Logger('redis.service.appendPollChart');
+
+export interface PieEntry {
+  label: string;
+  value: number;
+}
+
+/**
+ * Append (or update) a pie chart block summarising a poll's results to a meeting's
+ * Shared Notes pad.
+ *
+ * Unlike `pushInitialContent` (which seeds an empty pad), this APPENDS to a pad
+ * that already has content: it reads the current blocks and re-writes them plus the
+ * new chart. `blocksToYXmlFragment` diffs against the live Yjs fragment
+ * (y-prosemirror), so re-writing the unchanged blocks plus one new block is a
+ * minimal, append-only change that leaves existing notes intact.
+ *
+ * Idempotent by `pollId`: the poll id is embedded in the chart spec JSON, so a
+ * republished poll updates its existing chart in place instead of stacking a
+ * duplicate. The id lives inside `spec` on purpose - it keeps the block's propSchema
+ * (`{ spec: { default: '' } }`) byte-for-byte identical to the html5 client's; a
+ * dedicated prop would diverge the shared collaborative schema. The html5 validator
+ * (`parseChartSpec`) reads only `type` and `data`, so the extra field is ignored on
+ * render.
+ */
+export async function appendPollChartToNotes(
+  padId: string,
+  pollId: string,
+  data: PieEntry[],
+): Promise<{ statusCode: string; error?: string }> {
+  let connection: Awaited<ReturnType<typeof hocuspocus.openDirectConnection>> | null = null;
+  try {
+    const editor = getNotesEditor();
+    connection = await hocuspocus.openDirectConnection(padId);
+
+    const doc = connection.document;
+    if (!doc) {
+      return { statusCode: 'document_unavailable', error: 'Document not found' };
+    }
+
+    const fragment = doc.getXmlFragment('doc');
+    const spec = JSON.stringify({ type: 'pie', pollId, data });
+
+    const existingBlocks = editor.yXmlFragmentToBlocks(fragment);
+
+    let replaced = false;
+    // BlockNote's Block generics are intentionally loose here (`any`): we only read
+    // a string prop and shallow-copy, and the strongly-typed work is the pie data
+    // built upstream in the handler.
+    const nextBlocks = existingBlocks.map((block: any) => {
+      if (block?.type === 'chart' && typeof block?.props?.spec === 'string') {
+        try {
+          if (JSON.parse(block.props.spec)?.pollId === pollId) {
+            replaced = true;
+            return { ...block, props: { ...block.props, spec } };
+          }
+        } catch {
+          // Not a poll-managed chart spec; leave it untouched.
+        }
+      }
+      return block;
+    });
+
+    if (!replaced) {
+      nextBlocks.push({ type: 'chart', props: { spec } });
+    }
+
+    editor.blocksToYXmlFragment(nextBlocks, fragment);
+
+    logger.info('Poll chart written to notes', {
+      padId, pollId, replaced, slices: data.length,
+    });
+    return { statusCode: replaced ? 'chart_replaced' : 'chart_appended' };
+  } catch (error) {
+    logger.error('Error appending poll chart to notes', { error, padId, pollId });
+    return {
+      statusCode: 'unknown_error',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  } finally {
+    if (connection) await connection.disconnect();
+  }
+}

--- a/bbb-shared-notes-server/src/redis/service/notesSchema.ts
+++ b/bbb-shared-notes-server/src/redis/service/notesSchema.ts
@@ -1,0 +1,88 @@
+import { ServerBlockNoteEditor } from '@blocknote/server-util';
+import { BlockNoteSchema, createBlockSpec, defaultBlockSpecs } from '@blocknote/core';
+
+/**
+ * Shared Notes schema, server side.
+ *
+ * This MUST mirror the editor schema the html5 client builds in
+ * `bigbluebutton-html5/.../bn-shared-notes/component.tsx`: the default BlockNote
+ * blocks minus the media blocks the client strips (audio/image/file/video), plus
+ * the custom `latex` and `chart` blocks. The Shared Notes pad is one collaborative
+ * Yjs document shared by client and server, so any divergence in the block set
+ * would desync it - in particular the `chart` block's type/propSchema/content are
+ * kept byte-for-byte identical to `chart-block/ChartBlock.tsx`.
+ *
+ * A NodeView is only ever built when an editor view is mounted in a browser, which
+ * never happens in this headless server editor, so the blocks' `render` is never
+ * invoked here. It only has to exist so the block participates in the prosemirror
+ * schema used for the Yjs (de)serialization - hence the throw-if-called stub.
+ */
+
+const headlessRender = (): never => {
+  throw new Error('Shared Notes server block render must never run server-side');
+};
+
+// Kept byte-for-byte identical to the html5 chart block spec.
+const chartBlock = createBlockSpec(
+  {
+    type: 'chart',
+    propSchema: {
+      spec: {
+        default: '',
+      },
+    },
+    content: 'none',
+  },
+  { render: headlessRender },
+);
+
+// Mirrors the html5 latex block spec so latex blocks already in a pad survive the
+// read/append round-trip unchanged.
+const latexBlock = createBlockSpec(
+  {
+    type: 'latex',
+    propSchema: {
+      formula: {
+        default: '',
+      },
+      displayMode: {
+        default: false,
+      },
+    },
+    content: 'none',
+  },
+  { render: headlessRender },
+);
+
+function buildSchema() {
+  const {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    audio, image, file, video, ...remainingBlockSpecs
+  } = defaultBlockSpecs;
+
+  return BlockNoteSchema.create({
+    blockSpecs: {
+      ...remainingBlockSpecs,
+      latex: latexBlock(),
+      chart: chartBlock(),
+    },
+  });
+}
+
+function createNotesEditor() {
+  return ServerBlockNoteEditor.create({ schema: buildSchema() });
+}
+
+let cachedEditor: ReturnType<typeof createNotesEditor> | null = null;
+
+/**
+ * Lazily-built, reused server editor carrying the Shared Notes schema. The editor
+ * is stateless across conversions (each call operates on the fragment passed in),
+ * so a single instance is safe to share.
+ */
+export function getNotesEditor() {
+  if (!cachedEditor) {
+    cachedEditor = createNotesEditor();
+  }
+  return cachedEditor;
+}

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/basic-text-style-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/basic-text-style-button/component.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { useCallback } from 'react';
+import {
+  useBlockNoteEditor,
+  useComponentsContext,
+  useDictionary,
+  useEditorState,
+} from '@blocknote/react';
+import { formatKeyboardShortcut } from '@blocknote/core';
+import {
+  RiBold,
+  RiItalic,
+  RiStrikethrough,
+  RiUnderline,
+} from 'react-icons/ri';
+
+type BasicTextStyle = 'bold' | 'italic' | 'underline' | 'strike';
+
+const ICONS: Record<BasicTextStyle, React.ReactElement> = {
+  bold: <RiBold />,
+  italic: <RiItalic />,
+  underline: <RiUnderline />,
+  strike: <RiStrikethrough />,
+};
+
+// Custom replacement for BlockNote's BasicTextStyleButton. The native button
+// hides itself when none of the selected blocks have inline content
+// (`block.content !== undefined`). Our LaTeX custom block is declared
+// `content: 'none'`, so selecting/editing it makes every native style button
+// return null and the whole static formatting toolbar disappears.
+// This version keeps the button mounted regardless of the selected block type:
+// it only renders null when the style is missing from the schema or the editor
+// is read-only. On blocks without inline content the toggle is simply inert,
+// matching the always-visible behaviour of the static toolbar.
+function BasicTextStyleButton(
+  { basicTextStyle }: { basicTextStyle: BasicTextStyle },
+): React.ReactElement | null {
+  const dict = useDictionary();
+  const Components = useComponentsContext()!;
+  const editor = useBlockNoteEditor();
+
+  const state = useEditorState({
+    editor,
+    selector: ({ editor: e }) => {
+      const styleInSchema = basicTextStyle in e.schema.styleSchema
+        && e.schema.styleSchema[basicTextStyle].type === basicTextStyle
+        && e.schema.styleSchema[basicTextStyle].propSchema === 'boolean';
+      if (!e.isEditable || !styleInSchema) return undefined;
+      return { active: basicTextStyle in e.getActiveStyles() };
+    },
+  });
+
+  const toggleStyle = useCallback(() => {
+    editor.focus();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    editor.toggleStyles({ [basicTextStyle]: true } as any);
+  }, [editor, basicTextStyle]);
+
+  if (state === undefined) return null;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test={basicTextStyle}
+      onClick={toggleStyle}
+      isSelected={state.active}
+      label={dict.formatting_toolbar[basicTextStyle].tooltip}
+      mainTooltip={dict.formatting_toolbar[basicTextStyle].tooltip}
+      secondaryTooltip={formatKeyboardShortcut(
+        dict.formatting_toolbar[basicTextStyle].secondary_tooltip,
+        dict.generic.ctrl_shortcut,
+      )}
+      icon={ICONS[basicTextStyle]}
+    />
+  );
+}
+
+export default BasicTextStyleButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/block-type-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/block-type-select/component.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  BlockTypeSelect as NativeBlockTypeSelect,
+  useComponentsContext,
+} from '@blocknote/react';
+import { RiSquareRoot } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's BlockTypeSelect. The native select returns
+// null when no default block-type item matches the active block, which is the
+// case for our LaTeX custom block (`content: 'none'`, type not in the default
+// block-type list). That makes the first line of the static toolbar lose its
+// block-type control while editing a formula.
+//
+// On blocks with editable inline content we delegate to the native component
+// (full block-type switching). On content-less blocks we render an inert,
+// disabled select that still shows the current block ("LaTeX"), keeping the
+// toolbar layout stable. Switching a formula into a paragraph/heading from here
+// is meaningless, hence disabled.
+function BlockTypeSelect(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeBlockTypeSelect />;
+
+  return (
+    <Components.FormattingToolbar.Select
+      className="bn-select"
+      isDisabled
+      items={[
+        {
+          text: 'LaTeX',
+          icon: <RiSquareRoot size={16} />,
+          isSelected: true,
+          onClick: () => {},
+        },
+      ]}
+    />
+  );
+}
+
+export default BlockTypeSelect;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/chart-block/ChartBlock.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/chart-block/ChartBlock.tsx
@@ -1,0 +1,196 @@
+// @ts-nocheck -- BlockNote schema-generic types unresolved for custom block; same as LatexBlock
+import { createReactBlockSpec } from '@blocknote/react';
+import * as React from 'react';
+import {
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { parseChartSpec, ChartSpec } from './parseChartSpec';
+
+const SLICE_COLORS = [
+  '#0C57A7', '#F2C14E', '#3FA796', '#E36588', '#7E60BF',
+  '#F29E4C', '#5BC0BE', '#C03221', '#6A994E', '#577590',
+];
+
+const renderChart = (chart: ChartSpec) => {
+  if (chart.type === 'pie') {
+    return (
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Tooltip />
+          <Pie
+            data={chart.data}
+            dataKey="value"
+            nameKey="label"
+            outerRadius={100}
+            isAnimationActive={false}
+            label={(entry) => entry.label}
+          >
+            {chart.data.map((entry, index) => (
+              // Static, non-reordering slice list; color maps to position.
+              // eslint-disable-next-line react/no-array-index-key
+              <Cell key={`slice-${index}-${entry.label}`} fill={SLICE_COLORS[index % SLICE_COLORS.length]} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <ScatterChart>
+        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+        <XAxis type="number" dataKey="x" name="x" />
+        <YAxis type="number" dataKey="y" name="y" />
+        <Scatter data={chart.data} fill="#0C57A7" isAnimationActive={false} />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+};
+
+const ChartBlockContent: React.FC<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  block: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor: any;
+}> = ({ block, editor }) => {
+  const [editing, setEditing] = React.useState(
+    !block.props.spec || block.props.spec === '',
+  );
+  const [spec, setSpec] = React.useState(block.props.spec || '');
+  const [error, setError] = React.useState<string | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    setSpec(block.props.spec || '');
+  }, [block.props.spec]);
+
+  React.useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [editing]);
+
+  const renderSpec = () => {
+    if (!spec || spec.trim() === '') {
+      return (
+        <span className="chart-block-placeholder">
+          Click to insert a chart (pie or scatter JSON)
+        </span>
+      );
+    }
+    const result = parseChartSpec(spec);
+    if (!result.ok) {
+      return (
+        <span className="chart-block-error">
+          {result.error}
+        </span>
+      );
+    }
+    return renderChart(result.value);
+  };
+
+  const commitSpec = (newSpec: string) => {
+    const trimmed = newSpec.trim();
+    editor.updateBlock(block, {
+      type: 'chart' as const,
+      props: { spec: trimmed },
+    });
+    setError(null);
+    if (trimmed) {
+      const result = parseChartSpec(trimmed);
+      if (result.ok) {
+        setEditing(false);
+      } else {
+        setError(result.error);
+      }
+    } else {
+      setEditing(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && e.shiftKey) {
+      // Shift+Enter = commit and render
+      e.preventDefault();
+      commitSpec(spec);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setSpec(block.props.spec || '');
+      setError(null);
+      setEditing(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="chart-block chart-block-editing" contentEditable={false}>
+        <textarea
+          ref={textareaRef}
+          className="chart-block-textarea"
+          value={spec}
+          onChange={(e) => {
+            setSpec(e.target.value);
+            setError(null);
+          }}
+          onBlur={() => commitSpec(spec)}
+          onKeyDown={handleKeyDown}
+          placeholder={'{ "type": "pie", "data": [ { "label": "Yes", "value": 12 } ] }'}
+          rows={4}
+        />
+        {error && <div className="chart-block-error">{error}</div>}
+        <div className="chart-block-hint">
+          Press Enter+Shift to render &bull; Esc to cancel
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="chart-block chart-block-rendered"
+      contentEditable={false}
+      onClick={() => setEditing(true)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setEditing(true);
+        }
+      }}
+    >
+      <div className="chart-block-content">{renderSpec()}</div>
+    </div>
+  );
+};
+
+export const createChartBlock = createReactBlockSpec(
+  {
+    type: 'chart',
+    propSchema: {
+      spec: {
+        default: '',
+      },
+    },
+    content: 'none',
+  },
+  {
+    render: (props) => (
+      <ChartBlockContent
+        block={props.block}
+        editor={props.editor}
+      />
+    ),
+  },
+);
+
+export default createChartBlock;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/chart-block/parseChartSpec.test.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/chart-block/parseChartSpec.test.ts
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseChartSpec } from './parseChartSpec';
+
+test('valid pie spec is accepted', () => {
+  const result = parseChartSpec('{"type":"pie","data":[{"label":"Yes","value":12},{"label":"No","value":5}]}');
+  assert.equal(result.ok, true);
+  assert.ok(result.ok && result.value.type === 'pie');
+  assert.deepEqual(result.ok && result.value.data, [
+    { label: 'Yes', value: 12 },
+    { label: 'No', value: 5 },
+  ]);
+});
+
+test('valid scatter spec is accepted, label optional', () => {
+  const result = parseChartSpec('{"type":"scatter","data":[{"x":1,"y":4,"label":"p1"},{"x":2,"y":9}]}');
+  assert.equal(result.ok, true);
+  assert.ok(result.ok && result.value.type === 'scatter');
+  assert.deepEqual(result.ok && result.value.data, [
+    { x: 1, y: 4, label: 'p1' },
+    { x: 2, y: 9 },
+  ]);
+});
+
+test('scatter requires both x and y; entries missing either are dropped', () => {
+  const result = parseChartSpec('{"type":"scatter","data":[{"x":1},{"y":2},{"x":3,"y":4}]}');
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok && result.value.data, [{ x: 3, y: 4 }]);
+});
+
+test('scatter drops a non-string label but keeps the point', () => {
+  const result = parseChartSpec('{"type":"scatter","data":[{"x":1,"y":2,"label":5}]}');
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok && result.value.data, [{ x: 1, y: 2 }]);
+});
+
+test('pie entries with missing or wrong-typed fields are dropped', () => {
+  const result = parseChartSpec('{"type":"pie","data":[{"label":"A","value":3},{"label":"","value":1},{"label":"B"},{"value":2},{"label":"C","value":"x"}]}');
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok && result.value.data, [{ label: 'A', value: 3 }]);
+});
+
+test('pie rejects negative and non-finite values, keeps zero', () => {
+  const result = parseChartSpec('{"type":"pie","data":[{"label":"neg","value":-1},{"label":"zero","value":0}]}');
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok && result.value.data, [{ label: 'zero', value: 0 }]);
+});
+
+test('empty data yields a "No data" error', () => {
+  const result = parseChartSpec('{"type":"pie","data":[]}');
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.error === 'No data');
+});
+
+test('empty spec string yields a "No data" error', () => {
+  const result = parseChartSpec('   ');
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.error === 'No data');
+});
+
+test('malformed JSON yields an "Invalid JSON" error', () => {
+  const result = parseChartSpec('{type:pie}');
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.error === 'Invalid JSON');
+});
+
+test('unknown chart type is rejected', () => {
+  const result = parseChartSpec('{"type":"bar","data":[]}');
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.error === 'Unknown chart type');
+});
+
+test('non-array data is rejected', () => {
+  const result = parseChartSpec('{"type":"pie","data":{}}');
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.error === '"data" must be an array');
+});
+
+test('a top-level array (not an object) is rejected', () => {
+  const result = parseChartSpec('[]');
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.error === 'Spec must be an object');
+});

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/chart-block/parseChartSpec.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/chart-block/parseChartSpec.ts
@@ -1,0 +1,103 @@
+// Pure, React-free validator for the chart custom block's JSON spec.
+// BlockNote propSchema values are primitives only, so the chart is persisted as
+// a single JSON string and validated here at render time. Never throws: a
+// malformed spec must degrade to an inline error, never crash the collaborative
+// document.
+
+export interface PieEntry {
+  label: string;
+  value: number;
+}
+
+export interface ScatterEntry {
+  x: number;
+  y: number;
+  label?: string;
+}
+
+export interface PieChartSpec {
+  type: 'pie';
+  data: PieEntry[];
+}
+
+export interface ScatterChartSpec {
+  type: 'scatter';
+  data: ScatterEntry[];
+}
+
+export type ChartSpec = PieChartSpec | ScatterChartSpec;
+
+export type ParseChartResult =
+  | { ok: true; value: ChartSpec }
+  | { ok: false; error: string };
+
+const isFiniteNumber = (value: unknown): value is number => (
+  typeof value === 'number' && Number.isFinite(value)
+);
+
+const isNonEmptyString = (value: unknown): value is string => (
+  typeof value === 'string' && value.trim() !== ''
+);
+
+const parsePieData = (data: unknown[]): PieEntry[] => data.reduce<PieEntry[]>((acc, entry) => {
+  if (entry !== null && typeof entry === 'object') {
+    const { label, value } = entry as Record<string, unknown>;
+    if (isNonEmptyString(label) && isFiniteNumber(value) && value >= 0) {
+      acc.push({ label, value });
+    }
+  }
+  return acc;
+}, []);
+
+const parseScatterData = (data: unknown[]): ScatterEntry[] => data.reduce<ScatterEntry[]>((acc, entry) => {
+  if (entry !== null && typeof entry === 'object') {
+    const { x, y, label } = entry as Record<string, unknown>;
+    if (isFiniteNumber(x) && isFiniteNumber(y)) {
+      acc.push(isNonEmptyString(label) ? { x, y, label } : { x, y });
+    }
+  }
+  return acc;
+}, []);
+
+export function parseChartSpec(spec: string): ParseChartResult {
+  if (typeof spec !== 'string' || spec.trim() === '') {
+    return { ok: false, error: 'No data' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(spec);
+  } catch {
+    return { ok: false, error: 'Invalid JSON' };
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, error: 'Spec must be an object' };
+  }
+
+  const { type, data } = parsed as Record<string, unknown>;
+
+  if (type !== 'pie' && type !== 'scatter') {
+    return { ok: false, error: 'Unknown chart type' };
+  }
+
+  if (!Array.isArray(data)) {
+    return { ok: false, error: '"data" must be an array' };
+  }
+
+  if (type === 'pie') {
+    const pieData = parsePieData(data);
+    if (pieData.length === 0) {
+      return { ok: false, error: 'No data' };
+    }
+    return { ok: true, value: { type: 'pie', data: pieData } };
+  }
+
+  const scatterData = parseScatterData(data);
+  if (scatterData.length === 0) {
+    return { ok: false, error: 'No data' };
+  }
+  return { ok: true, value: { type: 'scatter', data: scatterData } };
+}
+
+export default parseChartSpec;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/color-style-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/color-style-button/component.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  ColorStyleButton as NativeColorStyleButton,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { RiFontColor } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's ColorStyleButton. The native button returns
+// null when none of the selected blocks have inline content
+// (`content !== undefined`). Our LaTeX custom block is declared `content: 'none'`,
+// so editing it hides the color control and breaks the first line of the static
+// toolbar.
+//
+// On blocks with editable inline content we delegate to the native component
+// (full text/background color picker). On content-less blocks text color does
+// not apply to the rendered formula, so we render an inert, disabled placeholder
+// that keeps the toolbar layout stable.
+function ColorStyleButton(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeColorStyleButton />;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test="colors"
+      isDisabled
+      label={dict.formatting_toolbar.colors.tooltip}
+      mainTooltip={dict.formatting_toolbar.colors.tooltip}
+      icon={<RiFontColor />}
+    />
+  );
+}
+
+export default ColorStyleButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -18,9 +18,16 @@ import {
   UnnestBlockButton,
   useComponentsContext,
   useCreateBlockNote,
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  DefaultReactSuggestionItem,
 } from '@blocknote/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Menu as MantineMenu } from '@mantine/core';
+import {
+  filterSuggestionItems,
+  insertOrUpdateBlockForSlashMenu,
+} from '@blocknote/core/extensions';
 
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
@@ -35,6 +42,8 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
+import createLatexBlock from './latex-block/LatexBlock';
+import 'katex/dist/katex.min.css';
 
 // Force-retain `Awareness` against a webpack tree-shaking interaction that
 // otherwise drops this class while keeping its `extends Observable` expression,
@@ -182,6 +191,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   const schema = BlockNoteSchema.create({
     blockSpecs: {
       ...remainingBlockSpecs,
+      latex: createLatexBlock(),
     },
   });
 
@@ -449,8 +459,27 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        slashMenu={false}
         renderEditor={false}
       >
+        <SuggestionMenuController
+          triggerCharacter="/"
+          getItems={async (query) => filterSuggestionItems(
+            [
+              ...getDefaultReactSlashMenuItems(editor),
+              {
+                title: 'LaTeX Formula',
+                onItemClick: () => {
+                  insertOrUpdateBlockForSlashMenu(editor, { type: 'latex' });
+                },
+                aliases: ['latex', 'math', 'formula', 'equation'],
+                group: 'Other',
+                subtext: 'Insert a LaTeX math formula',
+              } as DefaultReactSuggestionItem,
+            ],
+            query,
+          )}
+        />
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
           <ToolbarWithAccessibleMenus>
             <div

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -440,6 +440,18 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             bottom: auto !important;
             transform: translateY(0) !important;
           }
+          /* LaTeX block: remove selection outline and increase rendered formula size */
+          .ProseMirror-selectednode > .bn-block-content > .latex-block,
+          .bn-block-content.ProseMirror-selectednode > .latex-block {
+            outline: none !important;
+            border-radius: 0 !important;
+          }
+          .latex-block .katex {
+            font-size: 1.4em;
+          }
+          .latex-block-textarea::placeholder {
+            color: #9b9a97;
+          }
         `}
       </style>
       {notificationErrorMessage && (

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -8,14 +8,9 @@ import '@blocknote/mantine/style.css';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Awareness } from 'y-protocols/awareness';
 import {
-  BasicTextStyleButton,
   BlockNoteViewEditor,
-  BlockTypeSelect,
-  ColorStyleButton,
   ComponentsContext,
   FormattingToolbar,
-  NestBlockButton,
-  UnnestBlockButton,
   useComponentsContext,
   useCreateBlockNote,
   getDefaultReactSlashMenuItems,
@@ -42,6 +37,11 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
+import BasicTextStyleButton from './basic-text-style-button/component';
+import BlockTypeSelect from './block-type-select/component';
+import ColorStyleButton from './color-style-button/component';
+import NestBlockButton from './nest-block-button/component';
+import UnnestBlockButton from './unnest-block-button/component';
 import createLatexBlock from './latex-block/LatexBlock';
 import 'katex/dist/katex.min.css';
 

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -43,6 +43,7 @@ import ColorStyleButton from './color-style-button/component';
 import NestBlockButton from './nest-block-button/component';
 import UnnestBlockButton from './unnest-block-button/component';
 import createLatexBlock from './latex-block/LatexBlock';
+import createChartBlock from './chart-block/ChartBlock';
 import 'katex/dist/katex.min.css';
 
 // Force-retain `Awareness` against a webpack tree-shaking interaction that
@@ -192,6 +193,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
     blockSpecs: {
       ...remainingBlockSpecs,
       latex: createLatexBlock(),
+      chart: createChartBlock(),
     },
   });
 
@@ -452,6 +454,42 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .latex-block-textarea::placeholder {
             color: #9b9a97;
           }
+          /* Chart block: remove selection outline like the LaTeX block */
+          .ProseMirror-selectednode > .bn-block-content > .chart-block,
+          .bn-block-content.ProseMirror-selectednode > .chart-block {
+            outline: none !important;
+            border-radius: 0 !important;
+          }
+          .chart-block-rendered {
+            width: 100%;
+            cursor: pointer;
+          }
+          .chart-block-content {
+            width: 100%;
+          }
+          .chart-block-editing {
+            display: flex;
+            flex-direction: column;
+          }
+          .chart-block-textarea {
+            width: 100%;
+            font-family: monospace;
+            resize: vertical;
+          }
+          .chart-block-textarea::placeholder {
+            color: #9b9a97;
+          }
+          .chart-block-placeholder {
+            color: #9b9a97;
+          }
+          .chart-block-error {
+            color: #c03221;
+          }
+          .chart-block-hint {
+            color: #9b9a97;
+            font-size: 0.8em;
+            margin-top: 0.25em;
+          }
         `}
       </style>
       {notificationErrorMessage && (
@@ -487,6 +525,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
                 aliases: ['latex', 'math', 'formula', 'equation'],
                 group: 'Other',
                 subtext: 'Insert a LaTeX math formula',
+              } as DefaultReactSuggestionItem,
+              {
+                title: 'Chart',
+                onItemClick: () => {
+                  insertOrUpdateBlockForSlashMenu(editor, { type: 'chart' });
+                },
+                aliases: ['chart', 'pie', 'scatter', 'graph'],
+                group: 'Other',
+                subtext: 'Insert a pie or scatter chart from JSON',
               } as DefaultReactSuggestionItem,
             ],
             query,

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -219,6 +219,9 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   const STATIC_FORMATTING_TOOLBAR_ENABLED = window.meetingClientSettings
     ?.public?.sharedNotes?.staticFormattingToolbar ?? true;
 
+  const CONTAIN_TABLE_CONTROLS_OVERFLOW = window.meetingClientSettings
+    ?.public?.sharedNotes?.containTableControlsOverflow ?? true;
+
   const MAX_PASTE_SIZE = MAX_UPDATE_SHARED_NOTES * 1024;
 
   const intlRef = React.useRef(intl);
@@ -489,6 +492,24 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             color: #9b9a97;
             font-size: 0.8em;
             margin-top: 0.25em;
+          }
+        `}
+        {CONTAIN_TABLE_CONTROLS_OVERFLOW && `
+          /* Keep a wide table's floating "add row/column" handles inside the
+             narrow shared-notes panel. The table itself stays fully scrollable
+             via its own .tableWrapper (overflow-x: auto); only these absolutely
+             positioned handles, sized to the full table width, would otherwise
+             spill past the panel. Clamp them to the editor's visible content
+             width: 100cqw is the .bn-container inline size and 60px is the
+             editor's horizontal padding (padding-inline: 35px 25px above). The
+             left side menu is a separate handle and is left untouched. */
+          .bn-container {
+            container-type: inline-size;
+          }
+          .bn-extend-button-add-remove-rows,
+          .bn-extend-button-add-remove-columns {
+            max-width: calc(100cqw - 60px) !important;
+            min-width: 0 !important;
           }
         `}
       </style>

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
@@ -1,0 +1,166 @@
+// @ts-nocheck -- BlockNote schema-generic types unresolved for custom block; safe POC
+import { createReactBlockSpec } from '@blocknote/react';
+import * as React from 'react';
+import katex from 'katex';
+
+const LatexBlockContent: React.FC<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  block: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor: any;
+}> = ({ block, editor }) => {
+  const [editing, setEditing] = React.useState(
+    !block.props.formula || block.props.formula === '',
+  );
+  const [formula, setFormula] = React.useState(block.props.formula || '');
+  const [error, setError] = React.useState<string | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    setFormula(block.props.formula || '');
+  }, [block.props.formula]);
+
+  React.useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [editing]);
+
+  const renderFormula = () => {
+    if (!formula || formula.trim() === '') {
+      return (
+        <span className="latex-block-placeholder">
+          Click to insert LaTeX formula
+        </span>
+      );
+    }
+    try {
+      const html = katex.renderToString(formula, {
+        displayMode: block.props.displayMode ?? false,
+        throwOnError: true,
+      });
+      return (
+        <span
+          className="latex-block-rendered"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      );
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Invalid LaTeX';
+      return (
+        <span className="latex-block-error">
+          {msg}
+        </span>
+      );
+    }
+  };
+
+  const commitFormula = (newFormula: string) => {
+    const trimmed = newFormula.trim();
+    editor.updateBlock(block, {
+      type: 'latex' as const,
+      props: {
+        formula: trimmed,
+        displayMode: block.props.displayMode ?? false,
+      },
+    });
+    setError(null);
+    if (trimmed) {
+      try {
+        katex.renderToString(trimmed, {
+          displayMode: block.props.displayMode ?? false,
+          throwOnError: true,
+        });
+        setEditing(false);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Invalid LaTeX');
+      }
+    } else {
+      setEditing(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && e.shiftKey) {
+      // Shift+Enter = commit and render
+      e.preventDefault();
+      commitFormula(formula);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setFormula(block.props.formula || '');
+      setError(null);
+      setEditing(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="latex-block latex-block-editing" contentEditable={false}>
+        <div className="latex-block-label">LaTeX</div>
+        <textarea
+          ref={textareaRef}
+          className="latex-block-textarea"
+          value={formula}
+          onChange={(e) => {
+            setFormula(e.target.value);
+            setError(null);
+          }}
+          onBlur={() => commitFormula(formula)}
+          onKeyDown={handleKeyDown}
+          placeholder="E = mc^2 \\\\ \text{or try: } \\\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}"
+          rows={3}
+        />
+        {error && <div className="latex-block-error">{error}</div>}
+        <div className="latex-block-hint">
+          Press Enter+Shift to render &bull; Esc to cancel
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`latex-block latex-block-rendered ${block.props.displayMode ? 'latex-block-display' : 'latex-block-inline'}`}
+      contentEditable={false}
+      onClick={() => setEditing(true)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setEditing(true);
+        }
+      }}
+    >
+      <div className="latex-block-label">LaTeX</div>
+      <div className="latex-block-content">{renderFormula()}</div>
+    </div>
+  );
+};
+
+export const createLatexBlock = createReactBlockSpec(
+  {
+    type: 'latex',
+    propSchema: {
+      formula: {
+        default: '',
+      },
+      displayMode: {
+        default: false,
+      },
+    },
+    content: 'none',
+  },
+  {
+    render: (props) => {
+      return (
+        <LatexBlockContent
+          block={props.block}
+          editor={props.editor}
+        />
+      );
+    },
+  },
+);
+
+export default createLatexBlock;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
@@ -96,7 +96,6 @@ const LatexBlockContent: React.FC<{
   if (editing) {
     return (
       <div className="latex-block latex-block-editing" contentEditable={false}>
-        <div className="latex-block-label">LaTeX</div>
         <textarea
           ref={textareaRef}
           className="latex-block-textarea"
@@ -107,7 +106,7 @@ const LatexBlockContent: React.FC<{
           }}
           onBlur={() => commitFormula(formula)}
           onKeyDown={handleKeyDown}
-          placeholder="E = mc^2 \\\\ \text{or try: } \\\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}"
+          placeholder="Write something in LaTeX"
           rows={3}
         />
         {error && <div className="latex-block-error">{error}</div>}
@@ -132,7 +131,6 @@ const LatexBlockContent: React.FC<{
         }
       }}
     >
-      <div className="latex-block-label">LaTeX</div>
       <div className="latex-block-content">{renderFormula()}</div>
     </div>
   );

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/nest-block-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/nest-block-button/component.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  NestBlockButton as NativeNestBlockButton,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { RiIndentIncrease } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's NestBlockButton. The native button returns
+// null when none of the selected blocks have inline content
+// (`content !== undefined`). Our LaTeX custom block is declared `content: 'none'`,
+// so editing it hides the nest control and breaks the first line of the static
+// toolbar.
+//
+// On blocks with editable inline content we delegate to the native component
+// (it already disables itself when nesting is not possible). On content-less
+// blocks nesting a formula is meaningless, so we render an inert, disabled
+// placeholder that keeps the toolbar layout stable.
+function NestBlockButton(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeNestBlockButton />;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test="nestBlock"
+      isDisabled
+      label={dict.formatting_toolbar.nest.tooltip}
+      mainTooltip={dict.formatting_toolbar.nest.tooltip}
+      icon={<RiIndentIncrease />}
+    />
+  );
+}
+
+export default NestBlockButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -109,7 +109,22 @@ function TextAlignSelect(): React.ReactElement | null {
     [editor, state],
   );
 
-  if (!state) return null;
+  // The selector returns null for blocks without a textAlignment prop (e.g. our
+  // LaTeX custom block, declared `content: 'none'`). Returning null here would
+  // drop this control from the first line of the static toolbar. Instead render
+  // an inert, disabled placeholder so the toolbar layout stays stable; text
+  // alignment does not apply to a rendered formula.
+  if (!state) {
+    return (
+      <Components.FormattingToolbar.Button
+        className="bn-button"
+        isDisabled
+        label={dict.formatting_toolbar.align_left.tooltip}
+        mainTooltip={dict.formatting_toolbar.align_left.tooltip}
+        icon={<RiAlignLeft size={16} />}
+      />
+    );
+  }
 
   const currentItem = ALIGN_ITEMS.find((a) => a.value === state.alignment)!;
 

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/unnest-block-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/unnest-block-button/component.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  UnnestBlockButton as NativeUnnestBlockButton,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { RiIndentDecrease } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's UnnestBlockButton. The native button returns
+// null when none of the selected blocks have inline content
+// (`content !== undefined`). Our LaTeX custom block is declared `content: 'none'`,
+// so editing it hides the unnest control and breaks the first line of the static
+// toolbar.
+//
+// On blocks with editable inline content we delegate to the native component
+// (it already disables itself when unnesting is not possible). On content-less
+// blocks unnesting a formula is meaningless, so we render an inert, disabled
+// placeholder that keeps the toolbar layout stable.
+function UnnestBlockButton(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeUnnestBlockButton />;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test="unnestBlock"
+      isDisabled
+      label={dict.formatting_toolbar.unnest.tooltip}
+      mainTooltip={dict.formatting_toolbar.unnest.tooltip}
+      icon={<RiIndentDecrease />}
+    />
+  );
+}
+
+export default UnnestBlockButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/use-active-block-has-content.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/use-active-block-has-content.ts
@@ -1,0 +1,24 @@
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+
+// Returns whether the active selection contains at least one block with editable
+// inline content (`content !== undefined`).
+//
+// BlockNote's stock toolbar components (BlockTypeSelect, ColorStyleButton,
+// NestBlockButton, UnnestBlockButton) hide themselves - return null - when this
+// is false. Our LaTeX custom block is declared `content: 'none'`, so selecting
+// or editing it makes those components disappear and tears the first line of the
+// static formatting toolbar apart. The custom wrappers in the sibling folders
+// use this flag to keep those components mounted (inert) on content-less blocks,
+// mirroring the always-visible behaviour expected from a static toolbar.
+export default function useActiveBlockHasContent(): boolean {
+  const editor = useBlockNoteEditor();
+
+  return useEditorState({
+    editor,
+    selector: ({ editor: e }) => {
+      if (!e.isEditable) return false;
+      const blocks = e.getSelection()?.blocks ?? [e.getTextCursorPosition().block];
+      return blocks.some((block) => block.content !== undefined);
+    },
+  });
+}

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -51,6 +51,7 @@
         "hark": "^1.2.3",
         "html-to-image": "^1.11.13",
         "immutability-helper": "~2.8.1",
+        "katex": "^0.16.47",
         "langmap": "0.0.16",
         "livekit-client": "2.17.3",
         "makeup-screenreader-trap": "0.0.5",
@@ -7369,7 +7370,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -11578,6 +11578,22 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/keyv": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -94,6 +94,7 @@
     "hark": "^1.2.3",
     "html-to-image": "^1.11.13",
     "immutability-helper": "~2.8.1",
+    "katex": "^0.16.47",
     "langmap": "0.0.16",
     "livekit-client": "2.17.3",
     "makeup-screenreader-trap": "0.0.5",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -830,6 +830,13 @@ public:
     # editor and always visible. When disabled, BlockNote's default floating
     # toolbar appears only when text is selected.
     staticFormattingToolbar: true
+    # When enabled, the floating table "add row/column" handles are clamped to
+    # the editor's visible content width so a wide table's controls do not
+    # overflow the narrow shared-notes panel (the table itself stays fully
+    # scrollable). Configurable because the upstream BlockNote table-overflow
+    # fix is already released (0.51.0); an admin can disable this BBB override
+    # if a future @blocknote version makes it redundant or conflicting.
+    containTableControlsOverflow: true
   media:
     audio:
       # defaultFullAudioBridge: bridge to be used by full audio mechanism.

--- a/bigbluebutton-html5/tsconfig.json
+++ b/bigbluebutton-html5/tsconfig.json
@@ -41,6 +41,7 @@
     "./dist/*",
     "./.meteor/**",
     "./packages/**",
+    "./imports/**/*.test.ts",
     "node_modules",
     "./node_modules",
     "./node_modules/*",

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/latex-formatting-toolbar.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/latex-formatting-toolbar.spec.ts
@@ -1,0 +1,19 @@
+import { initializePages } from '../../core/helpers';
+import { test } from '../../core/setup/fixtures';
+import { BlockNoteSharedNotes } from './sharednotes';
+
+test.describe('Shared Notes - BlockNote LaTeX block', () => {
+  let sharedNotes: BlockNoteSharedNotes;
+
+  test.beforeEach(async ({ browser, context }, testInfo) => {
+    sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, {
+      createParameter: 'sharedNotesEditor=blockNote',
+      testInfo,
+    });
+  });
+
+  test('Formatting toolbar stays visible while editing a LaTeX block', async () => {
+    await sharedNotes.latexBlockKeepsFormattingToolbar();
+  });
+});

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -17,4 +17,8 @@ test.describe('Shared Notes - BlockNote', { tag: '@ci' }, () => {
     linkIssue(25122);
     await sharedNotes.exportEmptyNotesAsPDF();
   });
+
+  test('Wide table controls stay inside the shared notes panel', async () => {
+    await sharedNotes.tableControlsStayWithinPanel();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -4,6 +4,28 @@ import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constant
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 
+// BlockNote-internal selectors (the editor library does not expose data-test
+// attributes for these). The static formatting toolbar lives in the custom
+// `.bn-toolbar-row` container (see bn-shared-notes/component.tsx); each
+// BasicTextStyleButton renders with `data-test=<style>` (e.g. "bold").
+const blockNote = {
+  editor: '.bn-editor',
+  // Second toolbar line: BasicTextStyleButton renders with data-test=<style>.
+  toolbarBoldButton: '.bn-toolbar-row [data-test="bold"]',
+  // First toolbar line: color and nest buttons. Custom wrappers keep these
+  // mounted (inert) on the content-less LaTeX block; the native components hide
+  // them. They render with a stable `data-test` on both the native (text block)
+  // and the inert (LaTeX block) path, so they are reliable handles for "the
+  // first toolbar line is present". Each is separate so the test fails pointing
+  // at whichever button regressed. (The block-type select trigger has no stable
+  // selector - BlockNote's `.bn-select` class is on the open dropdown only.)
+  toolbarColorsButton: '.bn-toolbar-row [data-test="colors"]',
+  toolbarNestButton: '.bn-toolbar-row [data-test="nestBlock"]',
+  slashMenu: '.bn-suggestion-menu',
+  slashMenuItem: '.bn-suggestion-menu-item',
+  latexTextarea: '.latex-block-textarea',
+};
+
 export class BlockNoteSharedNotes extends MultiUsers {
   // Regression for https://github.com/bigbluebutton/bigbluebutton/issues/25122:
   // exporting an empty BlockNote shared note must return a file, not an error
@@ -75,5 +97,92 @@ export class BlockNoteSharedNotes extends MultiUsers {
       // eslint-disable-next-line no-await-in-loop
       if (body) body(await response.text());
     }
+  }
+
+  // Reproduces the bug where editing a LaTeX block hides the BlockNote
+  // formatting toolbar. The toolbar buttons (BasicTextStyleButton) only render
+  // when the active selection contains a block with editable text content
+  // (`content !== undefined`). The LaTeX custom block is declared `content:
+  // 'none'`, so as soon as it becomes the active block the bold/italic/etc.
+  // buttons return null and the toolbar disappears. It should stay visible.
+  async latexBlockKeepsFormattingToolbar() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+
+    const { page } = this.modPage;
+
+    // Open the BlockNote shared notes panel and wait for the editor.
+    await this.modPage.waitAndClick(e.sharedNotes, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.hasElement(
+      e.sharedNotesBackground,
+      'should display the shared notes panel',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.hasElement(blockNote.editor, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+
+    // Baseline: editing a normal text block keeps the full formatting toolbar
+    // visible. This also proves the selectors are correct (the toolbar exists
+    // and these are the right handles for "the formatting toolbar"). Both lines
+    // must be present: the second line (bold) and the first line (block type
+    // select, colors, nest).
+    await this.modPage.waitAndClick(blockNote.editor);
+    await page.keyboard.type('Baseline paragraph');
+    await this.modPage.hasElement(
+      blockNote.toolbarBoldButton,
+      'baseline: the second toolbar line (bold button) should be visible when editing a text block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarColorsButton,
+      'baseline: the first toolbar line (color button) should be visible when editing a text block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarNestButton,
+      'baseline: the first toolbar line (nest button) should be visible when editing a text block',
+    );
+
+    // Insert a LaTeX block via the slash menu (/latex -> "LaTeX Formula").
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('/latex');
+    await this.modPage.hasElement(blockNote.slashMenu, 'should display the slash command menu');
+    await page.locator(blockNote.slashMenuItem, { hasText: 'LaTeX Formula' }).first().click();
+
+    // A freshly inserted LaTeX block has an empty formula, so it opens directly
+    // in editing mode (its textarea is rendered and focused). Click it to make
+    // sure the LaTeX block is the active/edited block.
+    await this.modPage.hasElement(
+      blockNote.latexTextarea,
+      'should display the LaTeX block editing textarea',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.waitAndClick(blockNote.latexTextarea);
+
+    // Capture the editor state at the assertion point (toolbar should be here).
+    const screenshotPath = 'test-results/latex-formatting-toolbar.png';
+    await page.screenshot({ path: screenshotPath });
+    if (this.modPage.testInfo) {
+      await this.modPage.testInfo.attach('latex-block-editing', { path: screenshotPath });
+    }
+
+    // The bug: while editing the LaTeX block the toolbar lines disappear because
+    // the LaTeX block is `content: 'none'` and the stock toolbar components hide
+    // on content-less blocks. Both lines must remain visible: the second line
+    // (bold) and the first line (block type select, colors, nest).
+    await this.modPage.hasElement(
+      blockNote.toolbarBoldButton,
+      'the second toolbar line (bold button) should remain visible while editing a LaTeX block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarColorsButton,
+      'the first toolbar line (color button) should remain visible while editing a LaTeX block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarNestButton,
+      'the first toolbar line (nest button) should remain visible while editing a LaTeX block',
+    );
   }
 }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -24,6 +24,14 @@ const blockNote = {
   slashMenu: '.bn-suggestion-menu',
   slashMenuItem: '.bn-suggestion-menu-item',
   latexTextarea: '.latex-block-textarea',
+  table: '.bn-editor [data-content-type="table"] table',
+  tableWrapper: '.bn-editor .tableWrapper',
+  // Floating add-row table handle (BlockNote internal): it spans the full table
+  // width, so on a table wider than the panel its right edge overflows.
+  addRowHandle: '.bn-extend-button-add-remove-rows',
+  // The left block side menu (drag handle + "add block" button). It lives in
+  // the left gutter and must stay visible/accessible after the overflow fix.
+  sideMenu: '.bn-side-menu',
 };
 
 export class BlockNoteSharedNotes extends MultiUsers {
@@ -184,5 +192,98 @@ export class BlockNoteSharedNotes extends MultiUsers {
       blockNote.toolbarNestButton,
       'the first toolbar line (nest button) should remain visible while editing a LaTeX block',
     );
+  }
+
+  // A table wider than the narrow shared-notes panel must stay usable: the
+  // table itself scrolls horizontally (so every column is reachable) and the
+  // floating "add row/column" handles stay inside the editor instead of
+  // spilling out of the panel, while the left "add block" side menu remains
+  // visible. Without the containTableControlsOverflow fix the add-row handle is
+  // sized to the full table width and its right edge runs well past the editor.
+  async tableControlsStayWithinPanel() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+
+    const { page } = this.modPage;
+
+    await this.modPage.waitAndClick(e.sharedNotes, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.hasElement(
+      e.sharedNotesBackground,
+      'should display the shared notes panel',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.hasElement(blockNote.editor, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+
+    // Insert a table via the slash menu (/table -> "Table").
+    await this.modPage.waitAndClick(blockNote.editor);
+    await page.keyboard.type('/table');
+    await this.modPage.hasElement(blockNote.slashMenu, 'should display the slash command menu');
+    await page.keyboard.press('Enter');
+    await this.modPage.hasElement(blockNote.table, 'should insert a table', ELEMENT_WAIT_LONGER_TIME);
+
+    // The default BlockNote table is already wider than this narrow panel, so
+    // it overflows without any extra columns and exercises the fix directly.
+    const table = page.locator(blockNote.table);
+
+    // The table must be wider than its scroll container, i.e. it overflows the
+    // panel and so genuinely exercises the fix (and its columns are reachable
+    // only via horizontal scroll).
+    const wrapperScroll = await page.locator(blockNote.tableWrapper).evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(
+      wrapperScroll.scrollWidth,
+      'the table should be wider than the panel (its columns reachable via horizontal scroll)',
+    ).toBeGreaterThan(wrapperScroll.clientWidth);
+
+    // Hovering the table shows the left side menu ("add block"). BlockNote's
+    // floating handles fade in, so they are briefly not "visible" to Playwright
+    // even though they have real layout; wait for the element to attach and
+    // assert it has a real box inside the panel (the fix must not clip the left
+    // gutter). The panel's left edge is the lower bound.
+    await table.hover();
+    await page.locator(blockNote.sideMenu).waitFor({ state: 'attached', timeout: ELEMENT_WAIT_TIME });
+    const panel = await page.locator(e.sharedNotesBackground).evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right };
+    });
+    const sideMenuBox = await page.locator(blockNote.sideMenu).evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right, width: r.width };
+    });
+    expect(sideMenuBox.width, 'the add-block side menu should be rendered (non-zero width)').toBeGreaterThan(0);
+    expect(
+      sideMenuBox.left,
+      'the add-block side menu should not be clipped off the panel left edge',
+    ).toBeGreaterThanOrEqual(panel.left);
+    expect(sideMenuBox.right, 'the add-block side menu should stay inside the panel').toBeLessThanOrEqual(panel.right);
+
+    // Reveal the add-row handle by hovering near the table's bottom edge, then
+    // assert it does not overflow the editor's right edge.
+    const tableBox = await table.boundingBox();
+    if (!tableBox) throw new Error('could not measure the table');
+    await page.mouse.move(tableBox.x + Math.min(tableBox.width / 2, 150), tableBox.y + tableBox.height - 3);
+    await page.locator(blockNote.addRowHandle).waitFor({ state: 'attached', timeout: ELEMENT_WAIT_TIME });
+
+    const geometry = await page.evaluate((sel) => {
+      const rect = (s: string) => {
+        const el = document.querySelector(s);
+        return el ? el.getBoundingClientRect().right : null;
+      };
+      return { addRowRight: rect(sel.addRowHandle), editorRight: rect(sel.editor) };
+    }, blockNote);
+
+    expect(geometry.addRowRight, 'add-row handle should be present').not.toBeNull();
+    expect(geometry.editorRight, 'editor should be present').not.toBeNull();
+    expect(
+      geometry.addRowRight!,
+      'the add-row table handle should not overflow the editor (it must stay inside the panel)',
+    ).toBeLessThanOrEqual(geometry.editorRight!);
   }
 }

--- a/bigbluebutton-web/project/build.properties
+++ b/bigbluebutton-web/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/bigbluebutton-web/project/build.properties
+++ b/bigbluebutton-web/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2


### PR DESCRIPTION
## What is happening

The BigBlueButton shared-notes editor can run on BlockNote (the modern block-based editor) instead of the legacy Etherpad. When a meeting is created with `sharedNotesEditor=blockNote`, users get a Notion-like editing experience with slash commands, custom blocks (LaTeX, charts), and tables.

The shared-notes panel in BBB is intentionally narrow (~260px) so it behaves as a side panel alongside the presentation. BlockNote tables, however, default to a width that already exceeds this panel — and the floating "add row" handle that appears on hover (`+` below the last row) is sized to the **full table width** (`width: 100%`). The result: on a wide table, that handle spills past the panel's right edge and renders partly off-screen, which is the bug reported upstream in [TypeCellOS/BlockNote#2692](https://github.com/TypeCellOS/BlockNote/issues/2692).

## Why this happens (and why an upgrade doesn't fix it)

BlockNote's floating table handles used to portal to `document.body`, which broke their positioning. The upstream fix ([TypeCellOS/BlockNote#2729](https://github.com/TypeCellOS/BlockNote/pull/2729), released in `@blocknote` **0.51.0**) made the portal target configurable and moved the default back into `.bn-container`. **BBB already ships `@blocknote` 0.51.3**, so that upstream fix is already present.

The overflow that remains is BBB-specific: the panel is narrow, the default table is already wider than it, and `.bn-editor` uses `overflow-x: visible`, so the full-width handle spills instead of being contained. Upgrading `@blocknote` further does not address this — the cause lives in how the narrow panel interacts with the table handle sizing.

## The fix

A scoped CSS override inside the existing `bn-shared-notes` component (the same component already injects a `<style>` block of `.bn-*` overrides, so this follows the established pattern):

- Establish `.bn-container` as a container (`container-type: inline-size`).
- Clamp the floating add-row and add-column handles to the editor's visible content width: `max-width: calc(100cqw - 60px)` (where `100cqw` is the `.bn-container` inline size and `60px` is the editor's horizontal padding, `padding-inline: 35px 25px`).

Critically, **only the floating handles are clamped**:

- The table itself stays fully scrollable via its own `.tableWrapper` (`overflow-x: auto`) — every column remains reachable by scrolling, nothing is clipped.
- The left "add block" side menu (`.bn-side-menu`, the `+`/drag handle on the left gutter of each block) is **not** touched, so it is never clipped. A naive `overflow-x: hidden` on the container would clip both sides; this approach contains only the right-side overflow.

Because the upstream BlockNote fix is already released, the BBB override is made **configurable** via `public.sharedNotes.containTableControlsOverflow` (default `true`), mirroring the existing `staticFormattingToolbar` flag. An admin can disable this override if a future `@blocknote` version makes it redundant or conflicting.

## Behavior

### Before (flag off) — the add-row handle overflows the panel

Preview animated below — click the GIF to open the MP4 (higher quality, with controls):

[![Before fix: add-row handle overflows the panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/b9940632-0db0-4995-8d27-44ffb2bd3a88/blocknote-table-overflow-before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/d0f2b24c-0036-4f8c-862b-15e096caddfd/blocknote-table-overflow-before.mp4)

The floating `+` handle is pinned to the panel's right edge and overflows by ~150px (handle right edge at 649px vs editor right edge at 499px).

### After (flag on) — the handle stays inside the panel

Preview animated below — click the GIF to open the MP4 (higher quality, with controls):

[![After fix: handle clamped inside the panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/8c5a7de8-b483-4451-bbdb-a93a20271086/blocknote-table-overflow-after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/a6f5da3f-c0dd-46ad-9fcd-9663c6f8fcad/blocknote-table-overflow-after.mp4)

The handle is clamped (right edge at 474px ≤ editor 499px), the table grid stays intact and scrollable, and the left add-block side menu remains fully visible.

## Tests

New E2E test `sharednotes/blocknote` → `Wide table controls stay inside the shared notes panel` (`bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts`):

- Inserts a table via the slash menu and asserts the precondition (the table is wider than its scroll wrapper — i.e. it genuinely overflows the panel).
- Hovers the table and asserts the left add-block side menu (`.bn-side-menu`) stays inside the panel and is not clipped (non-zero width, left edge ≥ panel left, right edge ≤ panel right).
- Reveals the add-row handle and asserts its right edge does not exceed the editor's right edge.

Test evidence (geometry is the authoritative proof — the on-screen delta on the default table is modest, ~150px):

| State | add-row right edge | editor right edge | result |
|---|---|---|---|
| Flag **off** (before fix) | 649px | 499px | **FAIL** (~150px overflow) |
| Flag **on** (after fix) | 474px | 499px | **PASS** (handle inside) |

Full blocknote suite passes with the fix enabled (4/4: the new test, LaTeX toolbar visibility, export-empty-notes-as-PDF) — no regressions.

## Files changed

- `bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx` — flag read + scoped CSS clamp.
- `bigbluebutton-html5/private/config/settings.yml` — new `public.sharedNotes.containTableControlsOverflow` flag (default `true`).
- `bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts` — new test case.
- `bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts` — `tableControlsStayWithinPanel` helper + selectors.

## Notes / risks

- The `60px` constant in `calc(100cqw - 60px)` reflects the editor's current horizontal padding (`padding-inline: 35px 25px`). If that padding changes upstream, the clamp should be revisited — it is documented in a comment at the override site.
- The `.bn-extend-button-add-remove-columns` selector is included for symmetry/defensive coverage; in `@blocknote` 0.51.3 the column handle is `width: 18px` so the clamp is inert there today, but it guards against a future `width: 100%` regression on that handle.

Refs: [TypeCellOS/BlockNote#2692](https://github.com/TypeCellOS/BlockNote/issues/2692), [TypeCellOS/BlockNote#2729](https://github.com/TypeCellOS/BlockNote/pull/2729)

Co-Authored-By: Guilherme Leme <leme.guilherme.p@gmail.com>
