### PR TITLE
fix(shared-notes): keep BlockNote table add-row handle inside the panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -241,6 +241,9 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   const STATIC_FORMATTING_TOOLBAR_ENABLED = window.meetingClientSettings
     ?.public?.sharedNotes?.staticFormattingToolbar ?? true;
 
+  const CONTAIN_TABLE_CONTROLS_OVERFLOW = window.meetingClientSettings
+    ?.public?.sharedNotes?.containTableControlsOverflow ?? true;
+
   const MAX_PASTE_SIZE = MAX_UPDATE_SHARED_NOTES * 1024;
 
   const intlRef = React.useRef(intl);
@@ -470,6 +473,24 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             top: 1.5em !important;
             bottom: auto !important;
             transform: translateY(0) !important;
+          }
+        `}
+        {CONTAIN_TABLE_CONTROLS_OVERFLOW && `
+          /* Keep a wide table's floating "add row/column" handles inside the
+             narrow shared-notes panel. The table itself stays fully scrollable
+             via its own .tableWrapper (overflow-x: auto); only these absolutely
+             positioned handles, sized to the full table width, would otherwise
+             spill past the panel. Clamp them to the editor's visible content
+             width: 100cqw is the .bn-container inline size and 60px is the
+             editor's horizontal padding (padding-inline: 35px 25px above). The
+             left side menu is a separate handle and is left untouched. */
+          .bn-container {
+            container-type: inline-size;
+          }
+          .bn-extend-button-add-remove-rows,
+          .bn-extend-button-add-remove-columns {
+            max-width: calc(100cqw - 60px) !important;
+            min-width: 0 !important;
           }
         `}
       </style>

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -830,6 +830,13 @@ public:
     # editor and always visible. When disabled, BlockNote's default floating
     # toolbar appears only when text is selected.
     staticFormattingToolbar: true
+    # When enabled, the floating table "add row/column" handles are clamped to
+    # the editor's visible content width so a wide table's controls do not
+    # overflow the narrow shared-notes panel (the table itself stays fully
+    # scrollable). Configurable because the upstream BlockNote table-overflow
+    # fix is already released (0.51.0); an admin can disable this BBB override
+    # if a future @blocknote version makes it redundant or conflicting.
+    containTableControlsOverflow: true
   media:
     audio:
       # defaultFullAudioBridge: bridge to be used by full audio mechanism.

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -17,4 +17,8 @@ test.describe('Shared Notes - BlockNote', { tag: '@ci' }, () => {
     linkIssue(25122);
     await sharedNotes.exportEmptyNotesAsPDF();
   });
+
+  test('Wide table controls stay inside the shared notes panel', async () => {
+    await sharedNotes.tableControlsStayWithinPanel();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -4,6 +4,21 @@ import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constant
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 
+// BlockNote-internal selectors (the editor library does not expose data-test
+// attributes for these).
+const blockNote = {
+  editor: '.bn-editor',
+  slashMenu: '.bn-suggestion-menu',
+  table: '.bn-editor [data-content-type="table"] table',
+  tableWrapper: '.bn-editor .tableWrapper',
+  // Floating add-row table handle (BlockNote internal): it spans the full table
+  // width, so on a table wider than the panel its right edge overflows.
+  addRowHandle: '.bn-extend-button-add-remove-rows',
+  // The left block side menu (drag handle + "add block" button). It lives in
+  // the left gutter and must stay visible/accessible after the overflow fix.
+  sideMenu: '.bn-side-menu',
+};
+
 export class BlockNoteSharedNotes extends MultiUsers {
   // Regression for https://github.com/bigbluebutton/bigbluebutton/issues/25122:
   // exporting an empty BlockNote shared note must return a file, not an error
@@ -75,5 +90,98 @@ export class BlockNoteSharedNotes extends MultiUsers {
       // eslint-disable-next-line no-await-in-loop
       if (body) body(await response.text());
     }
+  }
+
+  // A table wider than the narrow shared-notes panel must stay usable: the
+  // table itself scrolls horizontally (so every column is reachable) and the
+  // floating "add row/column" handles stay inside the editor instead of
+  // spilling out of the panel, while the left "add block" side menu remains
+  // visible. Without the containTableControlsOverflow fix the add-row handle is
+  // sized to the full table width and its right edge runs well past the editor.
+  async tableControlsStayWithinPanel() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+
+    const { page } = this.modPage;
+
+    await this.modPage.waitAndClick(e.sharedNotes, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.hasElement(
+      e.sharedNotesBackground,
+      'should display the shared notes panel',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.hasElement(blockNote.editor, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+
+    // Insert a table via the slash menu (/table -> "Table").
+    await this.modPage.waitAndClick(blockNote.editor);
+    await page.keyboard.type('/table');
+    await this.modPage.hasElement(blockNote.slashMenu, 'should display the slash command menu');
+    await page.keyboard.press('Enter');
+    await this.modPage.hasElement(blockNote.table, 'should insert a table', ELEMENT_WAIT_LONGER_TIME);
+
+    // The default BlockNote table is already wider than this narrow panel, so
+    // it overflows without any extra columns and exercises the fix directly.
+    const table = page.locator(blockNote.table);
+
+    // The table must be wider than its scroll container, i.e. it overflows the
+    // panel and so genuinely exercises the fix (and its columns are reachable
+    // only via horizontal scroll).
+    const wrapperScroll = await page.locator(blockNote.tableWrapper).evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(
+      wrapperScroll.scrollWidth,
+      'the table should be wider than the panel (its columns reachable via horizontal scroll)',
+    ).toBeGreaterThan(wrapperScroll.clientWidth);
+
+    // Hovering the table shows the left side menu ("add block"). BlockNote's
+    // floating handles fade in, so they are briefly not "visible" to Playwright
+    // even though they have real layout; wait for the element to attach and
+    // assert it has a real box inside the panel (the fix must not clip the left
+    // gutter). The panel's left edge is the lower bound.
+    await table.hover();
+    await page.locator(blockNote.sideMenu).waitFor({ state: 'attached', timeout: ELEMENT_WAIT_TIME });
+    const panel = await page.locator(e.sharedNotesBackground).evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right };
+    });
+    const sideMenuBox = await page.locator(blockNote.sideMenu).evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right, width: r.width };
+    });
+    expect(sideMenuBox.width, 'the add-block side menu should be rendered (non-zero width)').toBeGreaterThan(0);
+    expect(
+      sideMenuBox.left,
+      'the add-block side menu should not be clipped off the panel left edge',
+    ).toBeGreaterThanOrEqual(panel.left);
+    expect(sideMenuBox.right, 'the add-block side menu should stay inside the panel').toBeLessThanOrEqual(panel.right);
+
+    // Reveal the add-row handle by hovering near the table's bottom edge, then
+    // assert it does not overflow the editor's right edge.
+    const tableBox = await table.boundingBox();
+    if (!tableBox) throw new Error('could not measure the table');
+    await page.mouse.move(tableBox.x + Math.min(tableBox.width / 2, 150), tableBox.y + tableBox.height - 3);
+    await page.locator(blockNote.addRowHandle).waitFor({ state: 'attached', timeout: ELEMENT_WAIT_TIME });
+
+    const geometry = await page.evaluate((sel) => {
+      const rect = (s: string) => {
+        const el = document.querySelector(s);
+        return el ? el.getBoundingClientRect().right : null;
+      };
+      return { addRowRight: rect(sel.addRowHandle), editorRight: rect(sel.editor) };
+    }, blockNote);
+
+    expect(geometry.addRowRight, 'add-row handle should be present').not.toBeNull();
+    expect(geometry.editorRight, 'editor should be present').not.toBeNull();
+    expect(
+      geometry.addRowRight!,
+      'the add-row table handle should not overflow the editor (it must stay inside the panel)',
+    ).toBeLessThanOrEqual(geometry.editorRight!);
   }
 }


### PR DESCRIPTION
## What is happening

The BigBlueButton shared-notes editor can run on BlockNote (the modern block-based editor) instead of the legacy Etherpad. When a meeting is created with `sharedNotesEditor=blockNote`, users get a Notion-like editing experience with slash commands and tables.

The shared-notes panel in BBB is intentionally narrow (~260px) so it behaves as a side panel alongside the presentation. BlockNote tables, however, default to a width that already exceeds this panel — and the floating "add row" handle that appears on hover (`+` below the last row) is sized to the **full table width** (`width: 100%`). The result: on a wide table, that handle spills past the panel's right edge and renders partly off-screen, which is the bug reported upstream in [TypeCellOS/BlockNote#2692](https://github.com/TypeCellOS/BlockNote/issues/2692).

## Why this happens (and why an upgrade doesn't fix it)

BlockNote's floating table handles used to portal to `document.body`, which broke their positioning. The upstream fix ([TypeCellOS/BlockNote#2729](https://github.com/TypeCellOS/BlockNote/pull/2729), released in `@blocknote` **0.51.0**) made the portal target configurable and moved the default back into `.bn-container`. **BBB already ships `@blocknote` 0.51.3**, so that upstream fix is already present.

The overflow that remains is BBB-specific: the panel is narrow, the default table is already wider than it, and `.bn-editor` uses `overflow-x: visible`, so the full-width handle spills instead of being contained. Upgrading `@blocknote` further does not address this — the cause lives in how the narrow panel interacts with the table handle sizing.

## The fix

A scoped CSS override inside the existing `bn-shared-notes` component (the same component already injects a `<style>` block of `.bn-*` overrides, so this follows the established pattern):

- Establish `.bn-container` as a container (`container-type: inline-size`).
- Clamp the floating add-row handle to the editor's visible content width: `max-width: calc(100cqw - 60px)` (where `100cqw` is the `.bn-container` inline size and `60px` is the editor's horizontal padding, `padding-inline: 35px 25px`).

Critically, **only the floating handle is clamped**:

- The table itself stays fully scrollable via its own `.tableWrapper` (`overflow-x: auto`) — every column remains reachable by scrolling, nothing is clipped.
- The left "add block" side menu (`.bn-side-menu`, the `+`/drag handle on the left gutter of each block) is **not** touched, so it is never clipped. A naive `overflow-x: hidden` on the container would clip both sides; this approach contains only the right-side overflow.

Because the upstream BlockNote fix is already released, the BBB override is made **configurable** via `public.sharedNotes.containTableControlsOverflow` (default `true`), mirroring the existing `staticFormattingToolbar` flag. An admin can disable this override if a future `@blocknote` version makes it redundant or conflicting.

## What about the "add column" handle?

Investigated and measured live in the from-source environment. The "add column" handle (`.bn-extend-button-add-remove-columns`) is a fixed `width: 18px` bar placed at the right edge of the **hovered last column**. BlockNote only renders it while that column is hovered, which requires scrolling the column into the visible wrapper first. Once visible, the handle sits at the scroll container's visible right edge: `474 + 4 + 18 = 496px`, within the editor's `499px` right edge.

So the add-column handle is **geometrically incapable of overflowing** the editor — with or without this fix (measured identical in both states across 4 scroll positions). The `.bn-extend-button-add-remove-columns` selector is kept in the CSS as a defensive no-op (it is inert today because the 18px width is always below the computed max-width), guarding against a hypothetical future `width: 100%` regression on that handle. No extension was needed.

## Behavior

### Before (flag off) — the add-row handle overflows the panel

Preview animated below — click the GIF to open the MP4 (higher quality, with controls):

[![Before fix: add-row handle overflows the panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/b9940632-0db0-4995-8d27-44ffb2bd3a88/blocknote-table-overflow-before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/d0f2b24c-0036-4f8c-862b-15e096caddfd/blocknote-table-overflow-before.mp4)

The floating `+` handle is pinned to the panel's right edge and overflows by ~150px (handle right edge at 649px vs editor right edge at 499px).

### After (flag on) — the handle stays inside the panel

Preview animated below — click the GIF to open the MP4 (higher quality, with controls):

[![After fix: handle clamped inside the panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/8c5a7de8-b483-4451-bbdb-a93a20271086/blocknote-table-overflow-after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-29/a6f5da3f-c0dd-46ad-9fcd-9663c6f8fcad/blocknote-table-overflow-after.mp4)

The handle is clamped (right edge at 474px ≤ editor 499px), the table grid stays intact and scrollable, and the left add-block side menu remains fully visible.

## Tests

New E2E test `sharednotes/blocknote` → `Wide table controls stay inside the shared notes panel` (`bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts`):

- Inserts a table via the slash menu and asserts the precondition (the table is wider than its scroll wrapper — i.e. it genuinely overflows the panel).
- Hovers the table and asserts the left add-block side menu (`.bn-side-menu`) stays inside the panel and is not clipped (non-zero width, left edge ≥ panel left, right edge ≤ panel right).
- Reveals the add-row handle and asserts its right edge does not exceed the editor's right edge.

Test evidence (geometry is the authoritative proof — the on-screen delta on the default table is modest, ~150px):

| State | add-row right edge | editor right edge | result |
|---|---|---|---|
| Flag **off** (before fix) | 649px | 499px | **FAIL** (~150px overflow) |
| Flag **on** (after fix) | 474px | 499px | **PASS** (handle inside) |

Full blocknote suite passes with the fix enabled (4/4: the new test, LaTeX toolbar visibility, export-empty-notes-as-PDF) — no regressions.

## Files changed

- `bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx` — flag read + scoped CSS clamp.
- `bigbluebutton-html5/private/config/settings.yml` — new `public.sharedNotes.containTableControlsOverflow` flag (default `true`).
- `bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts` — new test case.
- `bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts` — `tableControlsStayWithinPanel` helper + selectors.

## Notes / risks

- The `60px` constant in `calc(100cqw - 60px)` reflects the editor's current horizontal padding (`padding-inline: 35px 25px`). If that padding changes upstream, the clamp should be revisited — it is documented in a comment at the override site.
- The `.bn-extend-button-add-remove-columns` selector is included as defensive coverage; in `@blocknote` 0.51.3 the column handle is `width: 18px` and does not overflow, so the clamp is inert there today, but it guards against a future `width: 100%` regression on that handle.

Refs: [TypeCellOS/BlockNote#2692](https://github.com/TypeCellOS/BlockNote/issues/2692), [TypeCellOS/BlockNote#2729](https://github.com/TypeCellOS/BlockNote/pull/2729)

Co-Authored-By: Guilherme Leme <leme.guilherme.p@gmail.com>



---

> Replaces #26 — that PR had a stale base cache (stuck on a snapshot of `v3.0.x-develop` from before the fork was updated), so it displayed 34 commits even though the branch was clean. This PR is the same fix on a fresh base calculation.
