### PR TITLE
test(shared-notes): cover Markdown menu option gating

### DIFF
--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.spec.ts
@@ -48,6 +48,31 @@ test.describe.parallel('Shared Notes - BlockNote Markdown', { tag: '@ci' }, () =
     });
   });
 
+  test.describe('Menu option gating', () => {
+    let markdownSharedNotes: MarkdownSharedNotes;
+
+    test.beforeEach(async ({ browser, context }, testInfo) => {
+      markdownSharedNotes = new MarkdownSharedNotes(browser, context);
+      await initializePages(markdownSharedNotes, browser, {
+        isMultiUser: false,
+        createParameter: 'sharedNotesEditor=blocknote',
+        testInfo,
+      });
+    });
+
+    test('Markdown menu items are hidden by default', async () => {
+      await markdownSharedNotes.markdownOptionsHiddenByDefault();
+    });
+
+    test('Import from Markdown item is shown when importMarkdownEnabled is true', async () => {
+      await markdownSharedNotes.importMarkdownShownWhenEnabled();
+    });
+
+    test('Export as Markdown item is shown when exportMarkdownEnabled is true', async () => {
+      await markdownSharedNotes.exportMarkdownShownWhenEnabled();
+    });
+  });
+
   test.describe('Init from Markdown create parameter', () => {
     let markdownSharedNotes: MarkdownSharedNotes;
 

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
@@ -48,6 +48,57 @@ export function markdownCreateParameter(markdown: string): string {
 }
 
 export class MarkdownSharedNotes extends MultiUsers {
+  // Feature: by default both Markdown menu items are hidden (the import/export
+  // flags ship as false on BBB 3.0). Asserts the "off" baseline that the per-flag
+  // tests below flip.
+  async markdownOptionsHiddenByDefault() {
+    await startBlockNoteSharedNotes(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+
+    await expect(
+      this.modPage.page.locator(e.importNotesFromMarkdown),
+      'import-from-markdown should be hidden when importMarkdownEnabled is false',
+    ).toBeHidden();
+    await expect(
+      this.modPage.page.locator(e.exportNotesAsMarkdown),
+      'export-as-markdown should be hidden when exportMarkdownEnabled is false',
+    ).toBeHidden();
+  }
+
+  // Feature: turning importMarkdownEnabled on (leaving export off) surfaces only the
+  // import item; the export item stays hidden. Proves the two flags gate independently.
+  async importMarkdownShownWhenEnabled() {
+    await enableMarkdownNotesOptions(this.modPage, { importMarkdown: true, exportMarkdown: false });
+    await startBlockNoteSharedNotes(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+
+    await expect(
+      this.modPage.page.locator(e.importNotesFromMarkdown),
+      'import-from-markdown should be visible when importMarkdownEnabled is true',
+    ).toBeVisible();
+    await expect(
+      this.modPage.page.locator(e.exportNotesAsMarkdown),
+      'export-as-markdown should stay hidden when only importMarkdownEnabled is true',
+    ).toBeHidden();
+  }
+
+  // Feature: turning exportMarkdownEnabled on (leaving import off) surfaces only the
+  // export item; the import item stays hidden. The per-flag counterpart of the above.
+  async exportMarkdownShownWhenEnabled() {
+    await enableMarkdownNotesOptions(this.modPage, { importMarkdown: false, exportMarkdown: true });
+    await startBlockNoteSharedNotes(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+
+    await expect(
+      this.modPage.page.locator(e.exportNotesAsMarkdown),
+      'export-as-markdown should be visible when exportMarkdownEnabled is true',
+    ).toBeVisible();
+    await expect(
+      this.modPage.page.locator(e.importNotesFromMarkdown),
+      'import-from-markdown should stay hidden when only exportMarkdownEnabled is true',
+    ).toBeHidden();
+  }
+
   // Feature: "Export as Markdown" kebab item downloads a .md file with the notes.
   async exportAsMarkdown() {
     await enableMarkdownNotesOptions(this.modPage);

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -22,18 +22,28 @@ export async function startBlockNoteSharedNotes(testPage: Page): Promise<void> {
 // menu items off in a minor update), so the notes options menu hides them unless
 // the settings are turned on. The notes options menu bakes its items when it mounts
 // (opening the menu does not re-render it), so tests that exercise those items enable
-// both flags on the running client before opening shared notes. They are client-only
-// settings with no create-call parameter to seed them.
-export async function enableMarkdownNotesOptions(testPage: Page): Promise<void> {
-  await testPage.page.evaluate(() => {
-    const { sharedNotes } = (
-      globalThis as unknown as {
-        meetingClientSettings: { public: { sharedNotes: Record<string, boolean> } };
-      }
-    ).meetingClientSettings.public;
-    sharedNotes.importMarkdownEnabled = true;
-    sharedNotes.exportMarkdownEnabled = true;
-  });
+// the relevant flag(s) on the running client before opening shared notes. They are
+// client-only settings with no create-call parameter to seed them.
+export async function enableMarkdownNotesOptions(
+  testPage: Page,
+  options: { importMarkdown?: boolean; exportMarkdown?: boolean } = {},
+): Promise<void> {
+  // Default both flags on so existing callers keep the "enable everything" behaviour;
+  // gating tests pass only the flag they want to exercise so the other stays off.
+  const importMarkdown = options.importMarkdown ?? true;
+  const exportMarkdown = options.exportMarkdown ?? true;
+  await testPage.page.evaluate(
+    ({ importMarkdown, exportMarkdown }) => {
+      const { sharedNotes } = (
+        globalThis as unknown as {
+          meetingClientSettings: { public: { sharedNotes: Record<string, boolean> } };
+        }
+      ).meetingClientSettings.public;
+      sharedNotes.importMarkdownEnabled = importMarkdown;
+      sharedNotes.exportMarkdownEnabled = exportMarkdown;
+    },
+    { importMarkdown, exportMarkdown },
+  );
 }
 
 export function getBlockNoteEditorLocator(testPage: Page): Locator {


### PR DESCRIPTION
## Summary

Adds Playwright coverage for the per-flag gating of the BlockNote shared-notes Markdown menu items introduced in #25373. **No product code change - tests only.**

## Context

PR #25373 shipped two client-only flags that gate the Markdown import/export menu items in the BlockNote shared-notes dropdown:

- `public.sharedNotes.importMarkdownEnabled` gates the "Import from Markdown" item
- `public.sharedNotes.exportMarkdownEnabled` gates the "Export as Markdown" item

Both default to `false` on BBB 3.0 (a minor-version update must not surface a new menu button). The flags are read at dropdown mount time, so the menu bakes its items when it renders and does not re-render on toggle.

The existing test suite enabled both flags together before opening the notes panel, so the actual gating behaviour - each flag independently controlling its own menu item - was not covered.

## What this adds

Extends `enableMarkdownNotesOptions` (in `util.ts`) to toggle each flag independently, with the default unchanged (both on) so every existing caller keeps the "enable everything" behaviour. Then adds three tests in a new `Menu option gating` describe block:

1. `Markdown menu items are hidden by default` - with the shipped defaults, neither item is present in the notes options menu.
2. `Import from Markdown item is shown when importMarkdownEnabled is true` - only the import item appears; the export item stays hidden, proving the import flag does not leak into the export gate.
3. `Export as Markdown item is shown when exportMarkdownEnabled is true` - the symmetric counterpart for the export flag.

## How to enable the flags on a running server

These are client-only settings with no create-call parameter. Both default to `false` in `settings.yml` (lines 836 and 840):

- `importMarkdownEnabled: boolean`
- `exportMarkdownEnabled: boolean`

To enable them server-side, add `importMarkdownEnabled` / `exportMarkdownEnabled` under `public.sharedNotes` in `/etc/bigbluebutton/bbb-html5.yml`, then restart `bbb-apps-akka` (the override file is read once at akka boot, so editing the yml alone changes nothing) and create a **new** meeting. The merged settings are baked into each meeting at create time, so already-running meetings keep their old settings.

The tests do not touch the server: they toggle `window.meetingClientSettings.public.sharedNotes` via `page.evaluate` **before** opening the shared-notes panel, because the dropdown bakes its menu items at mount - toggling after the menu is open has no effect until the panel is reopened.

## Validation

Full `markdown.spec.ts` suite run against a BBB 3.0 from-source environment (`v3.0.x-develop` at `087090c0`, with #25373 merged), 16/16 passed:

```
  16 passed (1.3m)
```

Including the 3 new gating tests:

```
  ✓  Shared Notes - BlockNote Markdown › Menu option gating › Markdown menu items are hidden by default @ci (6.0s)
  ✓  Shared Notes - BlockNote Markdown › Menu option gating › Import from Markdown item is shown when importMarkdownEnabled is true @ci (6.5s)
  ✓  Shared Notes - BlockNote Markdown › Menu option gating › Export as Markdown item is shown when exportMarkdownEnabled is true @ci (6.3s)
```

Test-only PR; no UI or behaviour change to the product, so no video evidence is applicable - the passing test run is the proof.
