### PR TITLE
Fix link editing focus in BlockNote shared notes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -382,11 +382,14 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
 
   // Keep editor focus when clicking SideMenu/DragHandleMenu items.
   // Skip draggable="true" elements — preventDefault on mousedown prevents drag.
+  // Also skip form controls and BlockNote form popovers (e.g. the Edit-link popover) - stealing their
+  // native focus made link editing impossible (issue #25226).
   React.useEffect(() => {
     const { portalElement } = editor;
     if (!portalElement) return undefined;
     const mousedownHandler = (e: MouseEvent) => {
-      if ((e.target as HTMLElement).closest('[draggable="true"]')) return;
+      const target = e.target as HTMLElement;
+      if (target.closest('[draggable="true"], input, textarea, select, [contenteditable="true"], .bn-form-popover')) return;
       e.preventDefault();
       editor.focus();
     };

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -19,4 +19,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test("Collaboration cursor must not embed a user's name in a link", async () => {
     await blockNoteSharedNotes.collaborationCursorMustNotEmbedInLink();
   });
+
+  test('Link URL and text can be edited', async () => {
+    await blockNoteSharedNotes.linkUrlAndTextCanBeEdited();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -4,8 +4,11 @@ import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 import {
+  BLOCKNOTE_LINK_FORM,
+  BLOCKNOTE_LINK_TOOLBAR,
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
+  hoverBlockNoteLink,
   readLinkAndCursorState,
   startBlockNoteSharedNotes,
   WORD_JOINER,
@@ -15,6 +18,51 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async linkUrlAndTextCanBeEdited() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    await hoverBlockNoteLink(this.modPage);
+    await this.modPage.page
+      .locator(BLOCKNOTE_LINK_TOOLBAR)
+      .getByRole('button', { name: /edit link/i })
+      .click();
+
+    const form = this.modPage.page.locator(BLOCKNOTE_LINK_FORM);
+    const urlInput = form.locator('input').nth(0);
+    const textInput = form.locator('input').nth(1);
+    const editedUrl = `${LINK_URL}/bigbluebutton`;
+    const editedText = 'BigBlueButton repository';
+
+    await expect(urlInput, 'URL input should receive initial focus').toBeFocused();
+    await urlInput.click();
+    await expect(urlInput, 'URL input should retain focus when clicked').toBeFocused();
+    await urlInput.fill(editedUrl);
+    await textInput.click();
+    await expect(textInput, 'text input should retain focus when clicked').toBeFocused();
+    await textInput.fill(editedText);
+    await textInput.press('Enter');
+
+    await expect(link, 'should update the link text').toHaveText(editedText);
+    await expect(link, 'should update the link URL').toHaveAttribute('href', editedUrl);
+    await expect(editor, 'edited values should not be inserted as document text').not.toContainText(
+      `${LINK_URL} /bigbluebutton`,
+    );
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -7,6 +7,8 @@ import { Page } from '../../core/page';
 // The BlockNote editor renders inline (no Etherpad iframes); its editable area
 // is the ProseMirror root `.bn-editor` inside the shared-notes panel.
 export const BLOCKNOTE_EDITOR = '[data-test="notes"] .bn-editor';
+export const BLOCKNOTE_LINK_TOOLBAR = '.bn-link-toolbar';
+export const BLOCKNOTE_LINK_FORM = '.bn-form-popover';
 
 // U+2060 word-joiner: y-prosemirror wraps the remote collaboration-cursor name
 // in these invisible separators, which is what #25225 leaked into the link.
@@ -42,6 +44,22 @@ export function getBlockNoteEditorLocator(testPage: Page): Locator {
 
 export function getBlockNoteLinkLocator(testPage: Page): Locator {
   return testPage.page.locator(`${BLOCKNOTE_EDITOR} a`);
+}
+
+export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
+  const link = getBlockNoteLinkLocator(testPage);
+  const rect = await link.evaluate((element) => {
+    const clientRect = element.getClientRects()[0];
+    return {
+      x: clientRect.x,
+      y: clientRect.y,
+      width: clientRect.width,
+      height: clientRect.height,
+    };
+  });
+  await testPage.page.mouse.move(rect.x + 5, rect.y + rect.height / 2);
+  await testPage.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2, { steps: 5 });
+  await testPage.page.locator(BLOCKNOTE_LINK_TOOLBAR).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
 }
 
 /**


### PR DESCRIPTION


## Summary

- Preserve native focus for form controls rendered inside the BlockNote portal.
- Keep the existing focus restoration behavior for side menu and drag handle actions.
- Add a Playwright regression test covering URL and link text editing.

## Problem

This addresses item 3 of upstream issue 25226 (the Edit link option in BlockNote shared notes leads nowhere), reported in the main BigBlueButton repository.

The shared notes portal intercepted every `mousedown` event except draggable elements. Clicking an input in the link editor therefore focused the document and inserted subsequent typing into the note instead of the form.

## Solution

Form controls, editable elements, and BlockNote form popovers now keep their native focus behavior. Other portal actions continue restoring focus to the editor.

## Tests

- `npx playwright test sharednotes/blocknote/blocknote.spec.ts --project=chromium`
- `npm run typecheck`
- ESLint and Prettier checks for the changed files
- BBB 3.0 from-source manual validation (desktop Chromium only; mobile and other browsers not verified)

## Evidence

Before, at 00:25, typing after clicking the URL field is inserted into the document:

[Before video (MP4)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/d60c766a-126a-4ca0-8ede-cff0e30e9ad4/before-link-editing.mp4)

![Before: typed text lands in the document](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/e5ed970d-a1f6-439e-b72c-f02f6486ad64/before-bug-frame.png)

After, at 00:10, both the URL and title are updated successfully:

[![After: link popover keeps focus, URL and title edited](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/8b16ab26-be07-4b27-ac22-a669bde73c3c/after-link-editing.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/80ef7822-e375-4021-98f9-669a7e262ef5/after-link-editing.mp4)

![After: link edited end-to-end](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/25616df2-7408-4c13-b190-377c27bd1150/after-link-edited.png)

The original side menu focus behavior was also verified after deleting a block:

![Regression guard: side menu still restores editor focus](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/d57e5b68-233e-4d64-afa9-342dde32b712/after-focus-guard.png)

## Known limitation

The pre-existing horizontal overflow of the link editing popover in a narrow shared notes panel is unchanged.
