### PR TITLE
Fix BlockNote link editing focus

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -357,12 +357,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   }, [editable]);
 
   // Keep editor focus when clicking SideMenu/DragHandleMenu items.
-  // Skip draggable="true" elements — preventDefault on mousedown prevents drag.
+  // Skip native editable controls and BlockNote form popovers so their focus is preserved.
+  // Also skip draggable="true" elements — preventDefault on mousedown prevents drag.
   React.useEffect(() => {
     const { portalElement } = editor;
     if (!portalElement) return undefined;
     const mousedownHandler = (e: MouseEvent) => {
-      if ((e.target as HTMLElement).closest('[draggable="true"]')) return;
+      const target = e.target as HTMLElement;
+      const nativeEditableSelector = '[draggable="true"], input, textarea, select, [contenteditable="true"], .bn-form-popover';
+      if (target.closest(nativeEditableSelector)) return;
       e.preventDefault();
       editor.focus();
     };

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -263,6 +263,17 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
       renderCursor: renderCollaborationCursor,
     },
     schema,
+    links: {
+      onClick: (event) => {
+        if (event.ctrlKey || event.metaKey) {
+          const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>(
+            'a[data-inline-content-type="link"]',
+          );
+          if (anchor?.href) window.open(anchor.href, '_blank', 'noopener,noreferrer');
+        }
+        return true;
+      },
+    },
     dictionary: {
       ...BlockNoteLocales[blockNoteLocale as keyof typeof BlockNoteLocales],
       placeholders: {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -16,6 +16,7 @@ import {
   ColorStyleButton,
   ComponentsContext,
   FormattingToolbar,
+  LinkToolbarController,
   NestBlockButton,
   UnnestBlockButton,
   useComponentsContext,
@@ -488,6 +489,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        linkToolbar={false}
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
@@ -515,7 +517,14 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             </div>
           </ToolbarWithAccessibleMenus>
         )}
-        <BlockNoteViewEditor />
+        <BlockNoteViewEditor>
+          {/* Wrapped links use a union bounding box. Positioning below it keeps the
+              toolbar next to the last visual line while preserving BlockNote's
+              default offset, flip middleware, and horizontal alignment. */}
+          <LinkToolbarController
+            floatingUIOptions={{ useFloatingOptions: { placement: 'bottom-start' } }}
+          />
+        </BlockNoteViewEditor>
       </BlockNoteView>
       {isImportModalOpen && editable && (
         <MarkdownImportModal

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -16,6 +16,7 @@ import {
   ColorStyleButton,
   ComponentsContext,
   FormattingToolbar,
+  LinkToolbarController,
   NestBlockButton,
   UnnestBlockButton,
   useComponentsContext,
@@ -40,6 +41,7 @@ import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
 import MarkdownImportModal from './markdown-import-modal/component';
 import { useSharedNotesImport } from './import-context';
+import glueLinkToolbarToActiveLine from './link-toolbar-anchor';
 
 // Force-retain `Awareness` against a webpack tree-shaking interaction that
 // otherwise drops this class while keeping its `extends Observable` expression,
@@ -181,6 +183,13 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   } = props;
 
   const intl = useIntl();
+  const pointer = React.useRef({ x: -1, y: -1 });
+  const linkToolbarFloatingUIOptions = React.useMemo(() => ({
+    useFloatingOptions: {
+      placement: 'top-start' as const,
+      middleware: [glueLinkToolbarToActiveLine(pointer)],
+    },
+  }), []);
 
   const { isImportModalOpen, closeImportModal } = useSharedNotesImport();
 
@@ -380,7 +389,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   }, [editor]);
 
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <div
+      style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+      onMouseMove={(event) => {
+        pointer.current = { x: event.clientX, y: event.clientY };
+      }}
+    >
       <style>
         {`
           /* BlockNote ships Inter and hardcodes it; inherit the client font
@@ -488,6 +502,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        linkToolbar={false}
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
@@ -516,6 +531,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           </ToolbarWithAccessibleMenus>
         )}
         <BlockNoteViewEditor />
+        <LinkToolbarController floatingUIOptions={linkToolbarFloatingUIOptions} />
       </BlockNoteView>
       {isImportModalOpen && editable && (
         <MarkdownImportModal

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -16,7 +16,6 @@ import {
   ColorStyleButton,
   ComponentsContext,
   FormattingToolbar,
-  LinkToolbarController,
   NestBlockButton,
   UnnestBlockButton,
   useComponentsContext,
@@ -489,7 +488,6 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
-        linkToolbar={false}
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
@@ -517,14 +515,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             </div>
           </ToolbarWithAccessibleMenus>
         )}
-        <BlockNoteViewEditor>
-          {/* Wrapped links use a union bounding box. Positioning below it keeps the
-              toolbar next to the last visual line while preserving BlockNote's
-              default offset, flip middleware, and horizontal alignment. */}
-          <LinkToolbarController
-            floatingUIOptions={{ useFloatingOptions: { placement: 'bottom-start' } }}
-          />
-        </BlockNoteViewEditor>
+        <BlockNoteViewEditor />
       </BlockNoteView>
       {isImportModalOpen && editable && (
         <MarkdownImportModal

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -417,6 +417,11 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-mantine .bn-suggestion-menu {
             min-width: 300px;
           }
+          /* BlockNote fixes link form inputs at 300px, which overflows the
+             Shared Notes panel and scrolls the panel when an input is focused. */
+          .bn-mantine .bn-form-popover .mantine-TextInput-root {
+            width: 100%;
+          }
           /* Toolbar and editor are siblings inside .bn-container. DOM order matches
              visual order (toolbar first, editor second), so tab order is correct. */
           .bn-container {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/link-toolbar-anchor.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/link-toolbar-anchor.ts
@@ -1,0 +1,54 @@
+import type * as React from 'react';
+
+type Point = { x: number; y: number };
+
+type LinkToolbarMiddlewareState = {
+  x: number;
+  y: number;
+  elements: {
+    reference: Element | {
+      contextElement?: Element;
+    };
+  };
+};
+
+const pointInsideRect = (point: Point, rect: DOMRect) => (
+  point.x >= rect.left
+  && point.x <= rect.right
+  && point.y >= rect.top
+  && point.y <= rect.bottom
+);
+
+const glueLinkToolbarToActiveLine = (pointer: React.RefObject<Point>) => ({
+  name: 'glueLinkToolbarToActiveLine',
+  fn(state: LinkToolbarMiddlewareState) {
+    const { reference } = state.elements;
+    const link = reference instanceof Element ? reference : reference.contextElement;
+    if (!link) return {};
+
+    const rects = Array.from(link.getClientRects());
+    if (rects.length === 0) return {};
+
+    const selection = document.getSelection();
+    const caretRange = selection?.rangeCount
+      ? selection.getRangeAt(0)
+      : undefined;
+    const caretRect = caretRange && link.contains(caretRange.commonAncestorContainer)
+      ? caretRange.getBoundingClientRect()
+      : undefined;
+    const activePoint = caretRect
+      ? { x: caretRect.x, y: caretRect.y + caretRect.height / 2 }
+      : pointer.current;
+    const target = (activePoint && rects.find((rect) => pointInsideRect(activePoint, rect))) ?? rects[0];
+    const union = link.getBoundingClientRect();
+
+    // BlockNote anchors wrapped links to their union box. Rebase its virtual
+    // reference onto the active line because inline() cannot access its client rects.
+    return {
+      x: state.x + target.left - union.left,
+      y: state.y + target.top - union.top - 10,
+    };
+  },
+});
+
+export default glueLinkToolbarToActiveLine;

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -315,6 +315,8 @@ export const elements = {
   blockNoteEditable: '#bn-notes-scroll-container .bn-editor[contenteditable="true"]',
   blockNoteReadOnly: '#bn-notes-scroll-container .bn-editor[contenteditable="false"]',
   blockNoteToolbar: 'div[data-test="blockNoteToolbar"]',
+  blockNoteLinkToolbar: '.bn-link-toolbar',
+  blockNoteLinkForm: '.bn-form-popover',
   blockNoteUnderlineButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Underline"]',
   blockNoteAlignTextLeftButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Align text left"]',
   blockNoteSlashMenuItem: '.bn-suggestion-menu .bn-suggestion-menu-item',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -27,8 +27,4 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link editor must not overflow the notes panel', async () => {
     await blockNoteSharedNotes.linkEditorMustNotOverflowNotesPanel();
   });
-
-  test('Link toolbar must stay next to a wrapped link', async () => {
-    await blockNoteSharedNotes.linkToolbarMustStayNextToWrappedLink();
-  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -23,4 +23,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link URL and text can be edited', async () => {
     await blockNoteSharedNotes.linkUrlAndTextCanBeEdited();
   });
+
+  test('Link editor must not overflow the notes panel', async () => {
+    await blockNoteSharedNotes.linkEditorMustNotOverflowNotesPanel();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -19,4 +19,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test("Collaboration cursor must not embed a user's name in a link", async () => {
     await blockNoteSharedNotes.collaborationCursorMustNotEmbedInLink();
   });
+
+  test('Link URL and text can be edited', async () => {
+    await blockNoteSharedNotes.linkUrlAndTextCanBeEdited();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -27,4 +27,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link editor must not overflow the notes panel', async () => {
     await blockNoteSharedNotes.linkEditorMustNotOverflowNotesPanel();
   });
+
+  test('Link toolbar must stay next to a wrapped link', async () => {
+    await blockNoteSharedNotes.linkToolbarMustStayNextToWrappedLink();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -31,4 +31,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link toolbar must stay above the active line of a wrapped link', async () => {
     await blockNoteSharedNotes.linkToolbarMustStayNextToWrappedLink();
   });
+
+  test('Links open only on ctrl/cmd+click', async () => {
+    await blockNoteSharedNotes.linksOpenOnlyOnCtrlOrCmdClick();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -27,4 +27,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link editor must not overflow the notes panel', async () => {
     await blockNoteSharedNotes.linkEditorMustNotOverflowNotesPanel();
   });
+
+  test('Link toolbar must stay above the active line of a wrapped link', async () => {
+    await blockNoteSharedNotes.linkToolbarMustStayNextToWrappedLink();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,7 +6,7 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
-  hoverBlockNoteLink,
+  openBlockNoteLinkEditor,
   readLinkAndCursorState,
   startBlockNoteSharedNotes,
   WORD_JOINER,
@@ -33,11 +33,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
       timeout: ELEMENT_WAIT_LONGER_TIME,
     });
-    await hoverBlockNoteLink(this.modPage);
-    await this.modPage.page
-      .locator(e.blockNoteLinkToolbar)
-      .getByRole('button', { name: /edit link/i })
-      .click();
+    await openBlockNoteLinkEditor(this.modPage);
 
     const form = this.modPage.page.locator(e.blockNoteLinkForm);
     const urlInput = form.locator('input[name="url"]');
@@ -61,6 +57,45 @@ export class BlockNoteSharedNotes extends MultiUsers {
     );
   }
 
+  async linkEditorMustNotOverflowNotesPanel() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    const notesPanel = this.modPage.page.locator(e.sharedNotesBackground);
+    const panelX = (await notesPanel.boundingBox())?.x;
+    expect(panelX, 'shared notes panel should be visible').toBeDefined();
+
+    await openBlockNoteLinkEditor(this.modPage);
+    const form = this.modPage.page.locator(e.blockNoteLinkForm);
+    const urlInput = form.locator('input[name="url"]');
+    const textInput = form.locator('input[name="title"]');
+
+    expect((await notesPanel.boundingBox())?.x, 'opening the link editor must not move the notes panel').toBe(panelX);
+    await urlInput.click();
+    expect((await notesPanel.boundingBox())?.x, 'focusing the URL input must not move the notes panel').toBe(panelX);
+    await textInput.click();
+    expect((await notesPanel.boundingBox())?.x, 'focusing the text input must not move the notes panel').toBe(panelX);
+
+    const { scrollWidth, clientWidth } = await form.evaluate((element) => ({
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    }));
+    expect(scrollWidth, 'link editor content must fit within the popover').toBeLessThanOrEqual(clientWidth);
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.
@@ -68,7 +103,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
     const { sharedNotesEnabled } = this.modPage.settings || {};
     if (!sharedNotesEnabled) {
       await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
-      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
       return;
     }
 

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,6 +6,7 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
+  hoverBlockNoteLink,
   readLinkAndCursorState,
   startBlockNoteSharedNotes,
   WORD_JOINER,
@@ -15,6 +16,51 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async linkUrlAndTextCanBeEdited() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    await hoverBlockNoteLink(this.modPage);
+    await this.modPage.page
+      .locator(e.blockNoteLinkToolbar)
+      .getByRole('button', { name: /edit link/i })
+      .click();
+
+    const form = this.modPage.page.locator(e.blockNoteLinkForm);
+    const urlInput = form.locator('input[name="url"]');
+    const textInput = form.locator('input[name="title"]');
+    const editedUrl = `${LINK_URL}/bigbluebutton`;
+    const editedText = 'BigBlueButton repository';
+
+    await expect(urlInput, 'URL input should receive initial focus').toBeFocused();
+    await urlInput.click();
+    await expect(urlInput, 'URL input should retain focus when clicked').toBeFocused();
+    await urlInput.fill(editedUrl);
+    await textInput.click();
+    await expect(textInput, 'text input should retain focus when clicked').toBeFocused();
+    await textInput.fill(editedText);
+    await textInput.press('Enter');
+
+    await expect(link, 'should update the link text').toHaveText(editedText);
+    await expect(link, 'should update the link URL').toHaveAttribute('href', editedUrl);
+    await expect(editor, 'edited values should not be inserted as document text').not.toContainText(
+      `${LINK_URL} /bigbluebutton`,
+    );
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,8 +6,10 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
+  hoverBlockNoteLink,
   openBlockNoteLinkEditor,
   readLinkAndCursorState,
+  readLinkToolbarGeometry,
   startBlockNoteSharedNotes,
   WORD_JOINER,
 } from './util';
@@ -94,6 +96,42 @@ export class BlockNoteSharedNotes extends MultiUsers {
       clientWidth: element.clientWidth,
     }));
     expect(scrollWidth, 'link editor content must fit within the popover').toBeLessThanOrEqual(clientWidth);
+  }
+
+  async linkToolbarMustStayNextToWrappedLink() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    await hoverBlockNoteLink(this.modPage, -1);
+
+    const { rects, union, toolbar, panel } = await readLinkToolbarGeometry(this.modPage);
+    expect(rects.length, 'the URL should wrap across lines in the notes panel').toBeGreaterThan(1);
+    expect(union, 'the link should be visible').not.toBeNull();
+    expect(toolbar, 'the link toolbar should be visible').not.toBeNull();
+    expect(panel, 'the shared notes panel should be visible').not.toBeNull();
+    if (!union || !toolbar || !panel) return;
+
+    const linkBottom = union.y + union.height;
+    expect(toolbar.y, 'link toolbar should sit below the link, not above its first line').toBeGreaterThanOrEqual(
+      linkBottom,
+    );
+    expect(toolbar.y - linkBottom, 'link toolbar should stay adjacent to the link').toBeLessThanOrEqual(20);
+    expect(toolbar.y + toolbar.height, 'link toolbar should stay inside the notes panel').toBeLessThanOrEqual(
+      panel.y + panel.height,
+    );
   }
 
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -38,6 +38,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
       timeout: ELEMENT_WAIT_LONGER_TIME,
     });
     const context = this.modPage.page.context();
+    await context.route(LINK_URL, (route) => route.fulfill({ contentType: 'text/html', body: '' }));
     const plainClickPage = await Promise.all([
       context.waitForEvent('page', { timeout: 3000 }).catch(() => null),
       clickBlockNoteLink(this.modPage),

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -4,6 +4,7 @@ import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 import {
+  clickBlockNoteLink,
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
   hoverBlockNoteLink,
@@ -19,6 +20,40 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async linksOpenOnlyOnCtrlOrCmdClick() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    const context = this.modPage.page.context();
+    const plainClickPage = await Promise.all([
+      context.waitForEvent('page', { timeout: 3000 }).catch(() => null),
+      clickBlockNoteLink(this.modPage),
+    ]).then(([page]) => page);
+    expect(plainClickPage, 'a plain click must not open the link').toBeNull();
+    const caretInsideLink = await link.evaluate((anchor) => {
+      const selection = window.getSelection();
+      return !!selection?.anchorNode && anchor.contains(selection.anchorNode);
+    });
+    expect(caretInsideLink, 'a plain click should leave the caret inside the link').toBe(true);
+    await this.modPage.page.keyboard.press('Escape');
+    const [newPage] = await Promise.all([context.waitForEvent('page'), clickBlockNoteLink(this.modPage, true)]);
+    await expect.poll(() => newPage.url()).toBe(LINK_URL);
+    await newPage.close();
+  }
+
   async linkUrlAndTextCanBeEdited() {
     const { sharedNotesEnabled } = this.modPage.settings || {};
     if (!sharedNotesEnabled) {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,8 +6,11 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
+  hoverBlockNoteLink,
   openBlockNoteLinkEditor,
+  parkPointerAwayFromLink,
   readLinkAndCursorState,
+  readLinkToolbarGeometry,
   startBlockNoteSharedNotes,
   WORD_JOINER,
 } from './util';
@@ -94,6 +97,56 @@ export class BlockNoteSharedNotes extends MultiUsers {
       clientWidth: element.clientWidth,
     }));
     expect(scrollWidth, 'link editor content must fit within the popover').toBeLessThanOrEqual(clientWidth);
+  }
+
+  async linkToolbarMustStayNextToWrappedLink() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+
+    await hoverBlockNoteLink(this.modPage, -1);
+    const tailGeometry = await readLinkToolbarGeometry(this.modPage);
+    const { rects, union, toolbar, panel } = tailGeometry;
+    expect(rects.length, 'the URL should wrap across lines in the notes panel').toBeGreaterThan(1);
+    expect(union, 'the link should be visible').not.toBeNull();
+    expect(toolbar, 'the link toolbar should be visible').not.toBeNull();
+    expect(panel, 'the shared notes panel should be visible').not.toBeNull();
+    if (!union || !toolbar || !panel) return;
+
+    const tail = rects[rects.length - 1];
+    const toolbarBottom = toolbar.y + toolbar.height;
+    expect(toolbarBottom, 'link toolbar should stay above the pointed line').toBeLessThanOrEqual(tail.y + 1);
+    expect(tail.y - toolbarBottom, 'link toolbar should stay adjacent to the pointed line').toBeLessThanOrEqual(16);
+    expect(toolbarBottom, 'link toolbar should anchor past the wrapped link union top').toBeGreaterThan(union.y);
+
+    await parkPointerAwayFromLink(this.modPage);
+    await hoverBlockNoteLink(this.modPage, 0);
+    const headGeometry = await readLinkToolbarGeometry(this.modPage);
+    expect(headGeometry.toolbar, 'the link toolbar should be visible over the first line').not.toBeNull();
+    if (!headGeometry.toolbar) return;
+    const headToolbarBottom = headGeometry.toolbar.y + headGeometry.toolbar.height;
+    expect(headToolbarBottom, 'link toolbar should stay above the pointed first line').toBeLessThanOrEqual(
+      rects[0].y + 1,
+    );
+    expect(rects[0].y - headToolbarBottom, 'link toolbar should stay adjacent to the first line').toBeLessThanOrEqual(
+      16,
+    );
+    expect(toolbar.y + toolbar.height, 'link toolbar should stay inside the notes panel').toBeLessThanOrEqual(
+      panel.y + panel.height,
+    );
   }
 
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,10 +6,8 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
-  hoverBlockNoteLink,
   openBlockNoteLinkEditor,
   readLinkAndCursorState,
-  readLinkToolbarGeometry,
   startBlockNoteSharedNotes,
   WORD_JOINER,
 } from './util';
@@ -96,42 +94,6 @@ export class BlockNoteSharedNotes extends MultiUsers {
       clientWidth: element.clientWidth,
     }));
     expect(scrollWidth, 'link editor content must fit within the popover').toBeLessThanOrEqual(clientWidth);
-  }
-
-  async linkToolbarMustStayNextToWrappedLink() {
-    const { sharedNotesEnabled } = this.modPage.settings || {};
-    if (!sharedNotesEnabled) {
-      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
-      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
-      return;
-    }
-
-    await startBlockNoteSharedNotes(this.modPage);
-    const editor = getBlockNoteEditorLocator(this.modPage);
-    await editor.click();
-    await this.modPage.page.keyboard.type(`${LINK_URL} `);
-
-    const link = getBlockNoteLinkLocator(this.modPage);
-    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
-      timeout: ELEMENT_WAIT_LONGER_TIME,
-    });
-    await hoverBlockNoteLink(this.modPage, -1);
-
-    const { rects, union, toolbar, panel } = await readLinkToolbarGeometry(this.modPage);
-    expect(rects.length, 'the URL should wrap across lines in the notes panel').toBeGreaterThan(1);
-    expect(union, 'the link should be visible').not.toBeNull();
-    expect(toolbar, 'the link toolbar should be visible').not.toBeNull();
-    expect(panel, 'the shared notes panel should be visible').not.toBeNull();
-    if (!union || !toolbar || !panel) return;
-
-    const linkBottom = union.y + union.height;
-    expect(toolbar.y, 'link toolbar should sit below the link, not above its first line').toBeGreaterThanOrEqual(
-      linkBottom,
-    );
-    expect(toolbar.y - linkBottom, 'link toolbar should stay adjacent to the link').toBeLessThanOrEqual(20);
-    expect(toolbar.y + toolbar.height, 'link toolbar should stay inside the notes panel').toBeLessThanOrEqual(
-      panel.y + panel.height,
-    );
   }
 
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,39 +81,20 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
-export async function hoverBlockNoteLink(testPage: Page, fragmentIndex = 0): Promise<void> {
+export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
   const link = getBlockNoteLinkLocator(testPage);
-  const rect = await link.evaluate((element, index) => {
-    const rects = element.getClientRects();
-    const clientRect = rects[index < 0 ? rects.length + index : index];
+  const rect = await link.evaluate((element) => {
+    const clientRect = element.getClientRects()[0];
     return {
       x: clientRect.x,
       y: clientRect.y,
       width: clientRect.width,
       height: clientRect.height,
     };
-  }, fragmentIndex);
+  });
   await testPage.page.mouse.move(rect.x + 5, rect.y + rect.height / 2);
   await testPage.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2, { steps: 5 });
   await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
-}
-
-export async function readLinkToolbarGeometry(testPage: Page) {
-  const link = getBlockNoteLinkLocator(testPage);
-  const rects = await link.evaluate((element) =>
-    Array.from(element.getClientRects()).map((rect) => ({
-      x: rect.x,
-      y: rect.y,
-      width: rect.width,
-      height: rect.height,
-      bottom: rect.bottom,
-    })),
-  );
-  const union = await link.boundingBox();
-  const toolbar = await testPage.page.locator(e.blockNoteLinkToolbar).boundingBox();
-  const panel = await testPage.page.locator(e.sharedNotesBackground).boundingBox();
-
-  return { rects, union, toolbar, panel };
 }
 
 export async function openBlockNoteLinkEditor(testPage: Page): Promise<void> {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,6 +81,22 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
+export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
+  const link = getBlockNoteLinkLocator(testPage);
+  const rect = await link.evaluate((element) => {
+    const clientRect = element.getClientRects()[0];
+    return {
+      x: clientRect.x,
+      y: clientRect.y,
+      width: clientRect.width,
+      height: clientRect.height,
+    };
+  });
+  await testPage.page.mouse.move(rect.x + 5, rect.y + rect.height / 2);
+  await testPage.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2, { steps: 5 });
+  await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
 // Collects every uncaught exception raised by the client from now on. The array is
 // filled asynchronously, so it must be read *after* the interaction under test.
 export function collectPageErrors(testPage: Page): string[] {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,6 +81,25 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
+export async function clickBlockNoteLink(testPage: Page, withModifier = false): Promise<void> {
+  const link = getBlockNoteLinkLocator(testPage);
+  const { rect, bounds } = await link.evaluate((element) => {
+    const firstRect = element.getClientRects()[0];
+    const boundingRect = element.getBoundingClientRect();
+    return {
+      rect: { x: firstRect.x, y: firstRect.y, width: firstRect.width, height: firstRect.height },
+      bounds: { x: boundingRect.x, y: boundingRect.y },
+    };
+  });
+  await link.click({
+    modifiers: withModifier ? [process.platform === 'darwin' ? 'Meta' : 'Control'] : [],
+    position: {
+      x: rect.x - bounds.x + rect.width / 2,
+      y: rect.y - bounds.y + rect.height / 2,
+    },
+  });
+}
+
 export async function hoverBlockNoteLink(testPage: Page, fragmentIndex = 0): Promise<void> {
   const link = getBlockNoteLinkLocator(testPage);
   const rect = await link.evaluate((element, index) => {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,20 +81,44 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
-export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
+export async function hoverBlockNoteLink(testPage: Page, fragmentIndex = 0): Promise<void> {
   const link = getBlockNoteLinkLocator(testPage);
-  const rect = await link.evaluate((element) => {
-    const clientRect = element.getClientRects()[0];
+  const rect = await link.evaluate((element, index) => {
+    const rects = element.getClientRects();
+    const clientRect = rects[index < 0 ? rects.length + index : index];
     return {
       x: clientRect.x,
       y: clientRect.y,
       width: clientRect.width,
       height: clientRect.height,
     };
-  });
+  }, fragmentIndex);
   await testPage.page.mouse.move(rect.x + 5, rect.y + rect.height / 2);
   await testPage.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2, { steps: 5 });
   await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
+export async function parkPointerAwayFromLink(testPage: Page): Promise<void> {
+  await testPage.page.mouse.move(900, 600, { steps: 5 });
+  await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ state: 'detached', timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
+export async function readLinkToolbarGeometry(testPage: Page) {
+  const link = getBlockNoteLinkLocator(testPage);
+  const rects = await link.evaluate((element) =>
+    Array.from(element.getClientRects()).map((rect) => ({
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+      bottom: rect.bottom,
+    })),
+  );
+  const union = await link.boundingBox();
+  const toolbar = await testPage.page.locator(e.blockNoteLinkToolbar).boundingBox();
+  const panel = await testPage.page.locator(e.sharedNotesBackground).boundingBox();
+
+  return { rects, union, toolbar, panel };
 }
 
 export async function openBlockNoteLinkEditor(testPage: Page): Promise<void> {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -97,6 +97,15 @@ export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
   await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
 }
 
+export async function openBlockNoteLinkEditor(testPage: Page): Promise<void> {
+  await hoverBlockNoteLink(testPage);
+  await testPage.page
+    .locator(e.blockNoteLinkToolbar)
+    .getByRole('button', { name: /edit link/i })
+    .click();
+  await testPage.page.locator(e.blockNoteLinkForm).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
 // Collects every uncaught exception raised by the client from now on. The array is
 // filled asynchronously, so it must be read *after* the interaction under test.
 export function collectPageErrors(testPage: Page): string[] {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,20 +81,39 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
-export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
+export async function hoverBlockNoteLink(testPage: Page, fragmentIndex = 0): Promise<void> {
   const link = getBlockNoteLinkLocator(testPage);
-  const rect = await link.evaluate((element) => {
-    const clientRect = element.getClientRects()[0];
+  const rect = await link.evaluate((element, index) => {
+    const rects = element.getClientRects();
+    const clientRect = rects[index < 0 ? rects.length + index : index];
     return {
       x: clientRect.x,
       y: clientRect.y,
       width: clientRect.width,
       height: clientRect.height,
     };
-  });
+  }, fragmentIndex);
   await testPage.page.mouse.move(rect.x + 5, rect.y + rect.height / 2);
   await testPage.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2, { steps: 5 });
   await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
+export async function readLinkToolbarGeometry(testPage: Page) {
+  const link = getBlockNoteLinkLocator(testPage);
+  const rects = await link.evaluate((element) =>
+    Array.from(element.getClientRects()).map((rect) => ({
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+      bottom: rect.bottom,
+    })),
+  );
+  const union = await link.boundingBox();
+  const toolbar = await testPage.page.locator(e.blockNoteLinkToolbar).boundingBox();
+  const panel = await testPage.page.locator(e.sharedNotesBackground).boundingBox();
+
+  return { rects, union, toolbar, panel };
 }
 
 export async function openBlockNoteLinkEditor(testPage: Page): Promise<void> {


### PR DESCRIPTION
## Summary

In the shared notes, clicking the URL or the title field of the link edit popover closed the popover, and the text typed afterwards was inserted into the note body instead of updating the link (issue 25226). A mouse-down handler on the notes portal, added to keep editor focus for side-menu and drag-handle clicks, was stealing focus from the popover fields.

The skip list is extended to inputs, textareas, selects, contenteditable elements, and BlockNote form popovers, while side-menu and drag-handle behavior is preserved.

## Tests

- Added a Playwright regression test (Link URL and text can be edited) that edits both the URL and the display text, asserts each input retains focus after being clicked, asserts the updated link text and URL are rendered, and asserts edited values are not inserted into the document body.
- Validation scope: the new test was run on a 4.0 from-source environment with Chromium desktop only (2 passed); media features and mobile were not tested.
- Focal ESLint, Prettier and TypeScript checks on the changed files pass; repository-wide Prettier and TypeScript checks were already failing before this change (22 unformatted files and pre-existing type errors, none in the changed lines).

## Evidence

Before:

[Before video (MP4)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/c11f4aa1-7e75-4169-9d21-869baf852e7f/before.mp4)

![Before: typed text lands in the note](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/2c49f1dd-58f0-4f86-9144-18b5a446929d/05-after-typing-in-url-field.png)

After:

[After video (MP4)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/47574a7d-112b-4319-aef2-ac0dcaba0743/after.mp4)

![After: link edited end-to-end](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/1b24528b-f236-4cdb-abd8-27257d063135/05-after-typing-in-url-field.png)
## Link editor overflow follow-up

This update fixes the Shared Notes panel shift reported in issue 25226. BlockNote gives link form inputs a fixed 300px width, so the inputs overflow the narrower form popover and the browser scrolls the notes panel when either input receives focus. The inputs now use the available popover width.

The existing link editing flow now shares an `openBlockNoteLinkEditor` helper. A new E2E test verifies that opening the editor and focusing both inputs do not change the panel position, and that the popover content fits within its client width.

### Evidence

Before:

[![Before: link editor shifts the Shared Notes panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/a4171d66-d76e-4225-b1f3-21ba4a703a96/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/d1ea8cc5-87ac-4d6f-b426-3693d2533c7b/before.mp4)

After:

[![After: link editor remains inside the Shared Notes panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/d60d684a-320a-4a4a-9e6b-3ab7ed5b427f/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/090f4afb-8f8b-479d-bf04-b307e98496ae/after.mp4)

Validated: Shared Notes panel layout in desktop Chromium at 1280x800 and 1024x700 on BBB 4.0 from-source. The panel remains stationary, the popover no longer overflows, and link editing continues to work.

Not verified: mobile or `smallOnly`, Firefox or WebKit, notes pinned to the media area, and the Ctrl+K link creation path. Media was not tested.

Known limitation: the adjacent pre-existing `.bn-suggestion-menu` rule uses `min-width: 300px`, which can clip the command menu inside the narrow Shared Notes panel. This update does not change that behavior.


## Link toolbar vertical position follow-up (commit edb09cdc)

The link toolbar (hover pill and edit form) was anchored above the top-left of the link's union
bounding rect. For a link that wraps across lines, that placed the popover above the first line,
visually disconnected from the line the pointer is on. The change renders our own
LinkToolbarController (default one disabled via linkToolbar=false, same pattern already used for
the formatting toolbar) passing placement bottom-start, so the popover now appears 10px below the
active line, right next to the text being pointed at. No new dependencies; the default middleware
(offset, flip) is preserved, and flip() still moves it back above when the link is near the bottom
edge. Note: anchoring to the exact hovered fragment (multi-line aware) is a BlockNote upstream
limitation - the fix reported upstream keeps the vertical gap minimal on our side.

Before (popover above union top, disconnected):

[![Before: link toolbar above the first line](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/71139c3e-4a6a-46d8-86c0-1cd88a5dff95/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/a65cc69f-5637-46f6-8a7f-2782a66c2c77/before.mp4)

After (popover 10px below the hovered line):

[![After: link toolbar just below the hovered line](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/d7d114c5-60f8-4f80-b836-5f7401897032/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/4c72a7af-530e-4789-b2a1-04c91e2e4e2d/after.mp4)

Tests: new E2E case in bigbluebutton-tests (sharednotes/blocknote) asserting the link toolbar
renders below the hovered link line; full BlockNote suite green (5 passed including setup).


## Link toolbar glued above the pointed line (commits 345745b, 0129c19)

The previous follow-up (edb09cdc) placed the popover below the link line; per review feedback it
was reverted. This change keeps the popover above the link but re-anchors it to the link line the
user is actually on (resolution order: caret rect, pointer position, first client rect) via a
single custom middleware, keeping BlockNote's 10px gap. A link that wraps across lines now shows
the toolbar about 10px above the pointed line instead of a full line-height above the first line.
No new dependencies. Known trade-off: a 32px pill above a 21px line inevitably covers part of the
line above it - on a wrapped link, the link's own first line.

Before (popover a full line above the pointed line):

[![Before: toolbar far above the pointed line](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/caadac64-2167-4360-8539-733ee72eea7f/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/f3507f48-99f7-4771-b9c2-0bfbd6504bad/before.mp4)

After (popover glued about 10px above the pointed line):

[![After: toolbar glued above the pointed line](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/48cadbfd-45db-48de-bd9b-c562a90331e3/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/e438fe29-dc3c-4565-8946-2f2b38265fb5/after.mp4)

Final state screenshot:

![Final: link toolbar glued above the pointed line](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/7069f9b2-b5a1-4901-b0aa-0ab6d430531c/after.png)

Tests: the E2E case in bigbluebutton-tests (sharednotes/blocknote) was rewritten to assert the
toolbar renders about 10px above the pointed line, with an anti-regression assertion that fails on
the old union-box anchoring; full suite green (5 passed including setup).


## Links open only on ctrl/cmd+click in edit mode (commits f8aba717, 041506fd)

In shared notes edit mode, a plain click on a link no longer opens it; the link opens only with
ctrl+click (cmd+click on macOS), matching the convention of editor apps. Implemented through
BlockNote's official links.onClick option (available since 0.49, no new dependencies): the handler
blocks the default open unless ctrl/meta is held, keeping the caret inside the link on plain click.
Read-only/viewer behavior is intentionally unchanged - a viewer clicking a link still opens it,
since consuming content is the expected action in read mode, and the explicit open button remains
in the link toolbar.

Before (plain click opens a tab immediately):

[![Before: plain click opens a tab](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/a129d23f-528e-4222-a16d-29e7bae81462/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/1b77702d-5a84-4d7e-ae38-0f0366030ab5/before.mp4)

After (plain click: no new tab, caret stays; ctrl+click: exactly one new tab):

[![After: ctrl+click opens the link](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/248b580c-50f1-499f-8ce9-07a8ca99792d/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-21/d8d08265-5c42-4853-9fe3-08a30e0388aa/after.mp4)

Tests: new E2E case in bigbluebutton-tests (sharednotes/blocknote) asserting zero tabs on plain
click and exactly one tab with the link URL on ctrl+click, with a network stub so CI does not
depend on the real target site; full suite green (6 passed including setup).
